### PR TITLE
feat: support storing refresh token in insecure store

### DIFF
--- a/lib/sessionManager/index.ts
+++ b/lib/sessionManager/index.ts
@@ -11,6 +11,12 @@ export const storageSettings: StorageSettingsType = {
    * If the length is exceeded the items will be split into multiple storage items.
    */
   maxLength: 2000,
+  /**
+   * If to use the insecure store for refresh token.
+   *
+   * Note: This should only be used when there is no other secure storage available.
+   */
+  useInsecureForRefreshToken: false,
 };
 
 export { MemoryStorage } from "./stores/memory.js";

--- a/lib/sessionManager/types.ts
+++ b/lib/sessionManager/types.ts
@@ -17,6 +17,7 @@ export enum StorageKeys {
 export type StorageSettingsType = {
   keyPrefix: string;
   maxLength: number;
+  useInsecureForRefreshToken: boolean;
 };
 
 export abstract class SessionBase<V extends string = StorageKeys>

--- a/lib/utils/exchangeAuthCode.ts
+++ b/lib/utils/exchangeAuthCode.ts
@@ -3,6 +3,7 @@ import {
   getInsecureStorage,
   refreshToken,
   StorageKeys,
+  storageSettings,
 } from "../main";
 import { clearRefreshTimer, setRefreshTimer } from "./refreshTimer";
 
@@ -129,6 +130,10 @@ export const exchangeAuthCode = async ({
     [StorageKeys.idToken]: data.id_token,
     [StorageKeys.refreshToken]: data.refresh_token,
   });
+
+  if (storageSettings.useInsecureForRefreshToken) {
+    activeStorage.setSessionItem(StorageKeys.refreshToken, data.refresh_token);
+  }
 
   if (autoRefresh) {
     setRefreshTimer(data.expires_in, async () => {


### PR DESCRIPTION
# Explain your changes

For some front end only frameworks, for persistence have option to store the refresh token in insecure store 

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
