### PR TITLE
feat: add code verifier to generateAuthUrl reponse

### DIFF
--- a/lib/utils/generateAuthUrl.ts
+++ b/lib/utils/generateAuthUrl.ts
@@ -18,6 +18,7 @@ export const generateAuthUrl = async (
   state: string;
   nonce: string;
   codeChallenge: string;
+  codeVerifier: string;
 }> => {
   const authUrl = new URL(`${domain}/oauth2/auth`);
   const activeStorage = getInsecureStorage();
@@ -44,10 +45,12 @@ export const generateAuthUrl = async (
     activeStorage.setSessionItem(StorageKeys.nonce, options.nonce);
   }
 
+  let returnCodeVerifier = "";
   if (options.codeChallenge) {
     searchParams["code_challenge"] = options.codeChallenge;
   } else {
     const { codeVerifier, codeChallenge } = await generatePKCEPair();
+    returnCodeVerifier = codeVerifier;
     if (activeStorage) {
       activeStorage.setSessionItem(StorageKeys.codeVerifier, codeVerifier);
     }
@@ -65,6 +68,7 @@ export const generateAuthUrl = async (
     state: searchParams["state"],
     nonce: searchParams["nonce"],
     codeChallenge: searchParams["code_challenge"],
+    codeVerifier: returnCodeVerifier,
   };
 };
 

--- a/lib/utils/generateAuthUrl.ts
+++ b/lib/utils/generateAuthUrl.ts
@@ -20,7 +20,7 @@ export const generateAuthUrl = async (
   codeChallenge: string;
   codeVerifier: string;
 }> => {
-  const authUrl = new URL(`${domain}/oauth2/auth`);
+  const authPath = `${domain}/oauth2/auth`;
   const activeStorage = getInsecureStorage();
   const searchParams: Record<string, string> = {
     client_id: options.clientId,
@@ -62,9 +62,10 @@ export const generateAuthUrl = async (
     searchParams["code_challenge_method"] = options.codeChallengeMethod;
   }
 
-  authUrl.search = new URLSearchParams(searchParams).toString();
+  const queryString = new URLSearchParams(searchParams).toString();
+
   return {
-    url: authUrl,
+    url: new URL(`${authPath}?${queryString}`),
     state: searchParams["state"],
     nonce: searchParams["nonce"],
     codeChallenge: searchParams["code_challenge"],
@@ -78,7 +79,12 @@ export async function generatePKCEPair(): Promise<{
 }> {
   const codeVerifier = generateRandomString(52);
   const data = new TextEncoder().encode(codeVerifier);
-  const hashed = await crypto.subtle.digest("SHA-256", data);
-  const codeChallenge = base64UrlEncode(hashed);
+  let codeChallenge = "";
+  if (!crypto) {
+    codeChallenge = base64UrlEncode(btoa(codeVerifier));
+  } else {
+    const hashed = await crypto.subtle.digest("SHA-256", data);
+    codeChallenge = base64UrlEncode(hashed);
+  }
   return { codeVerifier, codeChallenge };
 }


### PR DESCRIPTION
# Explain your changes

extend the response from the `generateAuthUrl` method to return the code vertifier.

This allows more flexibility on implementation

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
