### PR TITLE
Fix `prompt` behaviour

### DIFF
--- a/lib/main.test.ts
+++ b/lib/main.test.ts
@@ -29,6 +29,7 @@ describe("index exports", () => {
     const expectedExports = [
       // types
       "IssuerRouteTypes",
+      "PromptTypes",
       "Scopes",
       "StorageKeys",
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,6 +5,12 @@ export enum Scopes {
   offline_access = "offline",
 }
 
+export enum PromptTypes {
+  none = "none",
+  create = "create",
+  login = "login",
+}
+
 export type LoginMethodParams = Pick<
   LoginOptions,
   | "audience"
@@ -72,12 +78,12 @@ export type LoginOptions = {
    * Prompt to use for the login
    *
    * This can be one of the following:
-   * - login
-   * - create
-   * - none
+   * - login (force user re-authentication)
+   * - create (show registration screen)
+   * - none (silently authenticate user without prompting for action)
    *
    */
-  prompt: string;
+  prompt?: PromptTypes;
   /**
    * Redirect URL to use for the login
    */
@@ -95,7 +101,7 @@ export type LoginOptions = {
    * - email
    * - profile
    * - openid
-   * - offline_access
+   * - offline
    */
   scope?: Scopes[];
   /**

--- a/lib/utils/generateAuthUrl.test.ts
+++ b/lib/utils/generateAuthUrl.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { IssuerRouteTypes, LoginOptions, Scopes } from "../types";
+import { IssuerRouteTypes, LoginOptions, PromptTypes, Scopes } from "../types";
 import { generateAuthUrl } from "./generateAuthUrl";
 import { MemoryStorage, StorageKeys } from "../sessionManager";
 import { setActiveStorage } from "./token";
@@ -24,7 +24,7 @@ describe("generateAuthUrl", () => {
     const result = await generateAuthUrl(
       domain,
       IssuerRouteTypes.login,
-      options,
+      options
     );
     const nonce = result.url.searchParams.get("nonce");
     expect(nonce).not.toBeNull();
@@ -53,7 +53,7 @@ describe("generateAuthUrl", () => {
     const result = await generateAuthUrl(
       domain,
       IssuerRouteTypes.register,
-      options,
+      options
     );
     const nonce = result.url.searchParams.get("nonce");
     expect(nonce).not.toBeNull();
@@ -73,7 +73,7 @@ describe("generateAuthUrl", () => {
       codeChallenge: "challenge123",
       codeChallengeMethod: "S256",
       redirectURL: "https://example2.com",
-      prompt: "login",
+      prompt: PromptTypes.login,
     };
     const expectedUrl =
       "https://auth.example.com/oauth2/auth?client_id=client123&response_type=code&redirect_uri=https%3A%2F%2Fexample2.com&audience=&scope=openid+profile&prompt=login&state=state123&code_challenge=challenge123&code_challenge_method=S256";
@@ -81,7 +81,7 @@ describe("generateAuthUrl", () => {
     const result = await generateAuthUrl(
       domain,
       IssuerRouteTypes.login,
-      options,
+      options
     );
     const nonce = result.url.searchParams.get("nonce");
     expect(nonce).not.toBeNull();
@@ -97,7 +97,7 @@ describe("generateAuthUrl", () => {
       clientId: "client123",
       scope: [Scopes.openid, Scopes.profile, Scopes.offline_access],
       redirectURL: "https://example2.com",
-      prompt: "create",
+      prompt: PromptTypes.create,
       state: "state123",
     };
     const expectedUrl =
@@ -106,7 +106,7 @@ describe("generateAuthUrl", () => {
     const result = await generateAuthUrl(
       domain,
       IssuerRouteTypes.login,
-      options,
+      options
     );
     const nonce = result.url.searchParams.get("nonce");
     expect(nonce).not.toBeNull();
@@ -126,7 +126,7 @@ describe("generateAuthUrl", () => {
       clientId: "client123",
       scope: [Scopes.openid, Scopes.profile, Scopes.offline_access],
       redirectURL: "https://example2.com",
-      prompt: "create",
+      prompt: PromptTypes.create,
     };
     const expectedUrl =
       "https://auth.example.com/oauth2/auth?client_id=client123&response_type=code&redirect_uri=https%3A%2F%2Fexample2.com&audience=&scope=openid+profile+offline&prompt=create&code_challenge_method=S256";
@@ -134,7 +134,7 @@ describe("generateAuthUrl", () => {
     const result = await generateAuthUrl(
       domain,
       IssuerRouteTypes.login,
-      options,
+      options
     );
     const nonce = result.url.searchParams.get("nonce");
     expect(nonce).not.toBeNull();
@@ -164,7 +164,7 @@ describe("generateAuthUrl", () => {
       connectionId: "conn123",
       redirectURL: "https://example.com",
       audience: "audience123",
-      prompt: "login",
+      prompt: PromptTypes.login,
     };
 
     await generateAuthUrl(domain, IssuerRouteTypes.login, options);

--- a/lib/utils/generateAuthUrl.test.ts
+++ b/lib/utils/generateAuthUrl.test.ts
@@ -24,7 +24,7 @@ describe("generateAuthUrl", () => {
     const result = await generateAuthUrl(
       domain,
       IssuerRouteTypes.login,
-      options
+      options,
     );
     const nonce = result.url.searchParams.get("nonce");
     expect(nonce).not.toBeNull();
@@ -53,7 +53,7 @@ describe("generateAuthUrl", () => {
     const result = await generateAuthUrl(
       domain,
       IssuerRouteTypes.register,
-      options
+      options,
     );
     const nonce = result.url.searchParams.get("nonce");
     expect(nonce).not.toBeNull();
@@ -81,7 +81,7 @@ describe("generateAuthUrl", () => {
     const result = await generateAuthUrl(
       domain,
       IssuerRouteTypes.login,
-      options
+      options,
     );
     const nonce = result.url.searchParams.get("nonce");
     expect(nonce).not.toBeNull();
@@ -106,7 +106,7 @@ describe("generateAuthUrl", () => {
     const result = await generateAuthUrl(
       domain,
       IssuerRouteTypes.login,
-      options
+      options,
     );
     const nonce = result.url.searchParams.get("nonce");
     expect(nonce).not.toBeNull();
@@ -134,7 +134,7 @@ describe("generateAuthUrl", () => {
     const result = await generateAuthUrl(
       domain,
       IssuerRouteTypes.login,
-      options
+      options,
     );
     const nonce = result.url.searchParams.get("nonce");
     expect(nonce).not.toBeNull();

--- a/lib/utils/generateAuthUrl.test.ts
+++ b/lib/utils/generateAuthUrl.test.ts
@@ -16,16 +16,15 @@ describe("generateAuthUrl", () => {
       connectionId: "conn123",
       redirectURL: "https://example.com",
       audience: "audience123",
-      prompt: "login",
       state: "state123",
     };
     const expectedUrl =
-      "https://auth.example.com/oauth2/auth?client_id=client123&response_type=code&start_page=login&login_hint=user%40example.com&is_create_org=true&connection_id=conn123&redirect_uri=https%3A%2F%2Fexample.com&audience=audience123&scope=openid+profile&prompt=login&state=state123&code_challenge_method=S256";
+      "https://auth.example.com/oauth2/auth?client_id=client123&response_type=code&login_hint=user%40example.com&is_create_org=true&connection_id=conn123&redirect_uri=https%3A%2F%2Fexample.com&audience=audience123&scope=openid+profile&state=state123&code_challenge_method=S256";
 
     const result = await generateAuthUrl(
       domain,
       IssuerRouteTypes.login,
-      options,
+      options
     );
     const nonce = result.url.searchParams.get("nonce");
     expect(nonce).not.toBeNull();
@@ -34,6 +33,33 @@ describe("generateAuthUrl", () => {
     const codeChallenge = result.url.searchParams.get("code_challenge");
     expect(codeChallenge!.length).toBeGreaterThanOrEqual(27);
     result.url.searchParams.delete("code_challenge");
+    expect(result.url.toString()).toBe(expectedUrl);
+  });
+
+  it("should generate the register URL when type is 'registration'", async () => {
+    const domain = "https://auth.example.com";
+    const options: LoginOptions = {
+      clientId: "client123",
+      responseType: "code",
+      scope: [Scopes.openid, Scopes.profile],
+      state: "state123",
+      codeChallenge: "challenge123",
+      codeChallengeMethod: "S256",
+      redirectURL: "https://example2.com",
+    };
+    const expectedUrl =
+      "https://auth.example.com/oauth2/auth?client_id=client123&response_type=code&redirect_uri=https%3A%2F%2Fexample2.com&audience=&scope=openid+profile&state=state123&code_challenge=challenge123&code_challenge_method=S256&prompt=create";
+
+    const result = await generateAuthUrl(
+      domain,
+      IssuerRouteTypes.register,
+      options
+    );
+    const nonce = result.url.searchParams.get("nonce");
+    expect(nonce).not.toBeNull();
+    expect(nonce!.length).toBe(16);
+    result.url.searchParams.delete("nonce");
+
     expect(result.url.toString()).toBe(expectedUrl);
   });
 
@@ -47,15 +73,15 @@ describe("generateAuthUrl", () => {
       codeChallenge: "challenge123",
       codeChallengeMethod: "S256",
       redirectURL: "https://example2.com",
-      prompt: "create",
+      prompt: "login",
     };
     const expectedUrl =
-      "https://auth.example.com/oauth2/auth?client_id=client123&response_type=code&start_page=login&redirect_uri=https%3A%2F%2Fexample2.com&audience=&scope=openid+profile&prompt=create&state=state123&code_challenge=challenge123&code_challenge_method=S256";
+      "https://auth.example.com/oauth2/auth?client_id=client123&response_type=code&redirect_uri=https%3A%2F%2Fexample2.com&audience=&scope=openid+profile&prompt=login&state=state123&code_challenge=challenge123&code_challenge_method=S256";
 
     const result = await generateAuthUrl(
       domain,
       IssuerRouteTypes.login,
-      options,
+      options
     );
     const nonce = result.url.searchParams.get("nonce");
     expect(nonce).not.toBeNull();
@@ -75,12 +101,12 @@ describe("generateAuthUrl", () => {
       state: "state123",
     };
     const expectedUrl =
-      "https://auth.example.com/oauth2/auth?client_id=client123&response_type=code&start_page=login&redirect_uri=https%3A%2F%2Fexample2.com&audience=&scope=openid+profile+offline&prompt=create&state=state123&code_challenge_method=S256";
+      "https://auth.example.com/oauth2/auth?client_id=client123&response_type=code&redirect_uri=https%3A%2F%2Fexample2.com&audience=&scope=openid+profile+offline&prompt=create&state=state123&code_challenge_method=S256";
 
     const result = await generateAuthUrl(
       domain,
       IssuerRouteTypes.login,
-      options,
+      options
     );
     const nonce = result.url.searchParams.get("nonce");
     expect(nonce).not.toBeNull();
@@ -103,12 +129,12 @@ describe("generateAuthUrl", () => {
       prompt: "create",
     };
     const expectedUrl =
-      "https://auth.example.com/oauth2/auth?client_id=client123&response_type=code&start_page=login&redirect_uri=https%3A%2F%2Fexample2.com&audience=&scope=openid+profile+offline&prompt=create&code_challenge_method=S256";
+      "https://auth.example.com/oauth2/auth?client_id=client123&response_type=code&redirect_uri=https%3A%2F%2Fexample2.com&audience=&scope=openid+profile+offline&prompt=create&code_challenge_method=S256";
 
     const result = await generateAuthUrl(
       domain,
       IssuerRouteTypes.login,
-      options,
+      options
     );
     const nonce = result.url.searchParams.get("nonce");
     expect(nonce).not.toBeNull();

--- a/lib/utils/generateAuthUrl.ts
+++ b/lib/utils/generateAuthUrl.ts
@@ -12,7 +12,7 @@ import { mapLoginMethodParamsForUrl } from "./mapLoginMethodParamsForUrl";
 export const generateAuthUrl = async (
   domain: string,
   type: IssuerRouteTypes = IssuerRouteTypes.login,
-  options: LoginOptions
+  options: LoginOptions,
 ): Promise<{
   url: URL;
   state: string;

--- a/lib/utils/generateAuthUrl.ts
+++ b/lib/utils/generateAuthUrl.ts
@@ -1,5 +1,5 @@
 import { base64UrlEncode, getInsecureStorage, StorageKeys } from "../main";
-import { IssuerRouteTypes, LoginOptions } from "../types";
+import { IssuerRouteTypes, LoginOptions, PromptTypes } from "../types";
 import { generateRandomString } from "./generateRandomString";
 import { mapLoginMethodParamsForUrl } from "./mapLoginMethodParamsForUrl";
 
@@ -12,7 +12,7 @@ import { mapLoginMethodParamsForUrl } from "./mapLoginMethodParamsForUrl";
 export const generateAuthUrl = async (
   domain: string,
   type: IssuerRouteTypes = IssuerRouteTypes.login,
-  options: LoginOptions,
+  options: LoginOptions
 ): Promise<{
   url: URL;
   state: string;
@@ -24,7 +24,6 @@ export const generateAuthUrl = async (
   const searchParams: Record<string, string> = {
     client_id: options.clientId,
     response_type: options.responseType || "code",
-    start_page: type,
     ...mapLoginMethodParamsForUrl(options),
   };
 
@@ -57,6 +56,10 @@ export const generateAuthUrl = async (
 
   if (options.codeChallengeMethod) {
     searchParams["code_challenge_method"] = options.codeChallengeMethod;
+  }
+
+  if (!options.prompt && type === IssuerRouteTypes.register) {
+    searchParams["prompt"] = PromptTypes.create;
   }
 
   authUrl.search = new URLSearchParams(searchParams).toString();

--- a/lib/utils/mapLoginMethodParamsForUrl.test.ts
+++ b/lib/utils/mapLoginMethodParamsForUrl.test.ts
@@ -1,7 +1,7 @@
 // mapLoginMethodParamsForUrl.test.ts
 import { describe, expect, it } from "vitest";
 import { mapLoginMethodParamsForUrl } from "./mapLoginMethodParamsForUrl";
-import { LoginMethodParams, Scopes } from "../types";
+import { LoginMethodParams, PromptTypes, Scopes } from "../types";
 
 describe("mapLoginMethodParamsForUrl", () => {
   it("should map login method params to URL parameters", () => {
@@ -12,7 +12,7 @@ describe("mapLoginMethodParamsForUrl", () => {
       redirectURL: "https://example.com",
       audience: "audience123",
       scope: [Scopes.openid, Scopes.profile],
-      prompt: "login",
+      prompt: PromptTypes.login,
       lang: "en",
       orgCode: "org123",
       orgName: "Example Org",


### PR DESCRIPTION
# Explain your changes

`start_page` was a Kinde implementation to allow the `register` page to be requested as part of the auth url, prior to the spec adding `create` as an option for the `prompt` parameter.

This change removes `start_page` in favour of using `prompt` (this shouldn't cause breaking changes as it is already the way that the PKCE SDK operates)

The inclusion of either `start_page=login` or `prompt=login` will always force Kinde to show the Login screen which often is not desired behaviour. Most of the time founders just wish the SSO session to continue. This PR removes the prompt being added by default and only adds when requested or if the a register auth url link has been requested.

Also fixed a small typo in one of the types

Types and Tests updated

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
