### PR TITLE
fix: custom domain with http prefix

### DIFF
--- a/lib/utils/isCustomDomain.test.ts
+++ b/lib/utils/isCustomDomain.test.ts
@@ -6,6 +6,10 @@ describe("isCustomDomain", () => {
     const result = isCustomDomain("www.test.com");
     expect(result).toEqual(true);
   });
+  it("protocol-prefixed kinde domain is not a custom domain", () => {
+    const result = isCustomDomain("https://test.kinde.com");
+    expect(result).toEqual(false);
+  });
   it("custom domain not in use", () => {
     const result = isCustomDomain("test.kinde.com");
     expect(result).toEqual(false);

--- a/lib/utils/isCustomDomain.ts
+++ b/lib/utils/isCustomDomain.ts
@@ -1,3 +1,5 @@
 export const isCustomDomain = (domain: string): boolean => {
-  return !domain.match("^[a-zA-Z]*.kinde.com");
+  return !domain.match(
+    /^(?:https?:\/\/)?[a-zA-Z0-9][-a-zA-Z0-9]*\.kinde\.com$/i,
+  );
 };


### PR DESCRIPTION
# Explain your changes

Fix an issue where the isCustomDomain check was returning protocol prefixed kinde domains as custom

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
