### PR TITLE
fix: insecure token storage when using no non custom domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,60 @@
 # Changelog
 
 
+## 0.7.1...fix/refresh_insecure_token_storage
+
+[compare changes](https://github.com/kinde-oss/js-utils/compare/0.7.1...fix/refresh_insecure_token_storage)
+
+### 🩹 Fixes
+
+- Insecure token storage when using no non custom domain ([7338321](https://github.com/kinde-oss/js-utils/commit/7338321))
+- Only show production warning when explicity setting the 'useInsecureForRefreshToken' ([958f4ed](https://github.com/kinde-oss/js-utils/commit/958f4ed))
+- Non prod kinde domains ([24be712](https://github.com/kinde-oss/js-utils/commit/24be712))
+
+### ✅ Tests
+
+- Add tests ([979974d](https://github.com/kinde-oss/js-utils/commit/979974d))
+
+### ❤️ Contributors
+
+- Daniel Rivers ([@DanielRivers](http://github.com/DanielRivers))
+
+## 0.7.1...fix/refresh_insecure_token_storage
+
+[compare changes](https://github.com/kinde-oss/js-utils/compare/0.7.1...fix/refresh_insecure_token_storage)
+
+### 🩹 Fixes
+
+- Insecure token storage when using no non custom domain ([7338321](https://github.com/kinde-oss/js-utils/commit/7338321))
+- Only show production warning when explicity setting the 'useInsecureForRefreshToken' ([958f4ed](https://github.com/kinde-oss/js-utils/commit/958f4ed))
+- Non prod kinde domains ([24be712](https://github.com/kinde-oss/js-utils/commit/24be712))
+
+### ✅ Tests
+
+- Add tests ([979974d](https://github.com/kinde-oss/js-utils/commit/979974d))
+
+### ❤️ Contributors
+
+- Daniel Rivers ([@DanielRivers](http://github.com/DanielRivers))
+
+## 0.7.1...fix/refresh_insecure_token_storage
+
+[compare changes](https://github.com/kinde-oss/js-utils/compare/0.7.1...fix/refresh_insecure_token_storage)
+
+### 🩹 Fixes
+
+- Insecure token storage when using no non custom domain ([7338321](https://github.com/kinde-oss/js-utils/commit/7338321))
+- Only show production warning when explicity setting the 'useInsecureForRefreshToken' ([958f4ed](https://github.com/kinde-oss/js-utils/commit/958f4ed))
+- Non prod kinde domains ([24be712](https://github.com/kinde-oss/js-utils/commit/24be712))
+
+### ✅ Tests
+
+- Add tests ([979974d](https://github.com/kinde-oss/js-utils/commit/979974d))
+
+### ❤️ Contributors
+
+- Daniel Rivers ([@DanielRivers](http://github.com/DanielRivers))
+
 ## 0.7.0...main
 
 [compare changes](https://github.com/kinde-oss/js-utils/compare/0.7.0...main)

--- a/lib/sessionManager/stores/localStorage.test.ts
+++ b/lib/sessionManager/stores/localStorage.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { LocalStorage } from "./localStorage";
 import { StorageKeys } from "../types";
+import { storageSettings } from "..";
 
 enum ExtraKeys {
   testKey = "testKey2",
@@ -31,6 +32,22 @@ describe("LocalStorage standard keys", () => {
 
   beforeEach(() => {
     sessionManager = new LocalStorage();
+  });
+
+  it("should show warning when using local storage access token explicity", async () => {
+    storageSettings.useInsecureForRefreshToken = true;
+    const consoleSpy = vi.spyOn(console, "warn");
+    new LocalStorage();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "LocalStorage store should not be used in production",
+    );
+    storageSettings.useInsecureForRefreshToken = false;
+  });
+
+  it("should not show warning when using secure refresh tokens", async () => {
+    const consoleSpy = vi.spyOn(console, "warn");
+    new LocalStorage();
+    expect(consoleSpy).not.toHaveBeenCalled();
   });
 
   it("should set and get an item in session storage", async () => {

--- a/lib/sessionManager/stores/localStorage.ts
+++ b/lib/sessionManager/stores/localStorage.ts
@@ -12,7 +12,9 @@ export class LocalStorage<V extends string = StorageKeys>
 {
   constructor() {
     super();
-    console.warn("LocalStorage store should not be used in production");
+    if (storageSettings.useInsecureForRefreshToken) {
+      console.warn("LocalStorage store should not be used in production");
+    }
   }
 
   private internalItems: Set<V | StorageKeys> = new Set<V>();

--- a/lib/utils/exchangeAuthCode.ts
+++ b/lib/utils/exchangeAuthCode.ts
@@ -30,7 +30,7 @@ type ExchangeAuthCodeResultSuccess = {
   [StorageKeys.accessToken]?: string;
   [StorageKeys.idToken]?: string;
   [StorageKeys.refreshToken]?: string;
-}
+};
 
 type ExchangeAuthCodeResultError = {
   success: false;
@@ -38,9 +38,11 @@ type ExchangeAuthCodeResultError = {
   [StorageKeys.accessToken]?: never;
   [StorageKeys.idToken]?: never;
   [StorageKeys.refreshToken]?: never;
-}
+};
 
-type ExchangeAuthCodeResult = ExchangeAuthCodeResultSuccess | ExchangeAuthCodeResultError
+type ExchangeAuthCodeResult =
+  | ExchangeAuthCodeResultSuccess
+  | ExchangeAuthCodeResultError;
 
 export const exchangeAuthCode = async ({
   urlParams,

--- a/lib/utils/exchangeAuthCode.ts
+++ b/lib/utils/exchangeAuthCode.ts
@@ -97,7 +97,7 @@ export const exchangeAuthCode = async ({
     headers["Kinde-SDK"] =
       `${frameworkSettings.framework}/${frameworkSettings.frameworkVersion}`;
   }
-  const response = await fetch(`${domain}/oauth2/token`, {
+  const fetchOptions: RequestInit = {
     method: "POST",
     ...(isCustomDomain(domain) && { credentials: "include" }),
     headers: new Headers(headers),
@@ -108,7 +108,9 @@ export const exchangeAuthCode = async ({
       grant_type: "authorization_code",
       redirect_uri: redirectURL,
     }),
-  });
+  };
+  console.log("fetchOptions", fetchOptions);
+  const response = await fetch(`${domain}/oauth2/token`, fetchOptions);
   if (!response?.ok) {
     const errorText = await response.text();
     console.error("Token exchange failed:", response.status, errorText);
@@ -135,7 +137,7 @@ export const exchangeAuthCode = async ({
     });
   }
 
-  if (storageSettings.useInsecureForRefreshToken) {
+  if (storageSettings.useInsecureForRefreshToken || !isCustomDomain(domain)) {
     activeStorage.setSessionItem(StorageKeys.refreshToken, data.refresh_token);
   }
 

--- a/lib/utils/exchangeAuthCode.ts
+++ b/lib/utils/exchangeAuthCode.ts
@@ -24,13 +24,23 @@ interface ExchangeAuthCodeParams {
   autoRefresh?: boolean;
 }
 
-interface ExchangeAuthCodeResult {
-  success: boolean;
-  error?: string;
+type ExchangeAuthCodeResultSuccess = {
+  success: true;
+  error?: never;
   [StorageKeys.accessToken]?: string;
   [StorageKeys.idToken]?: string;
   [StorageKeys.refreshToken]?: string;
 }
+
+type ExchangeAuthCodeResultError = {
+  success: false;
+  error: string;
+  [StorageKeys.accessToken]?: never;
+  [StorageKeys.idToken]?: never;
+  [StorageKeys.refreshToken]?: never;
+}
+
+type ExchangeAuthCodeResult = ExchangeAuthCodeResultSuccess | ExchangeAuthCodeResultError
 
 export const exchangeAuthCode = async ({
   urlParams,

--- a/lib/utils/exchangeAuthCode.ts
+++ b/lib/utils/exchangeAuthCode.ts
@@ -121,7 +121,7 @@ export const exchangeAuthCode = async ({
       redirect_uri: redirectURL,
     }),
   };
-  console.log("fetchOptions", fetchOptions);
+
   const response = await fetch(`${domain}/oauth2/token`, fetchOptions);
   if (!response?.ok) {
     const errorText = await response.text();

--- a/lib/utils/generateAuthUrl.test.ts
+++ b/lib/utils/generateAuthUrl.test.ts
@@ -177,4 +177,24 @@ describe("generateAuthUrl", () => {
     expect(nonce).toBeDefined();
     expect(codeVerifier).toBeDefined();
   });
+
+  it("if state is defined, ensure its stored in correctly", async () => {
+    const store = new MemoryStorage();
+    setActiveStorage(store);
+
+    const testState = "testState:123";
+    const domain = "https://auth.example.com";
+    const options: LoginOptions = {
+      clientId: "client123",
+      redirectURL: "https://example.com",
+      prompt: PromptTypes.login,
+      state: testState
+    };
+
+    await generateAuthUrl(domain, IssuerRouteTypes.login, options);
+
+    const state = await store.getSessionItem(StorageKeys.state);
+
+    expect(state).toEqual(testState);
+  });
 });

--- a/lib/utils/generateAuthUrl.test.ts
+++ b/lib/utils/generateAuthUrl.test.ts
@@ -188,7 +188,7 @@ describe("generateAuthUrl", () => {
       clientId: "client123",
       redirectURL: "https://example.com",
       prompt: PromptTypes.login,
-      state: testState
+      state: testState,
     };
 
     await generateAuthUrl(domain, IssuerRouteTypes.login, options);

--- a/lib/utils/generateAuthUrl.ts
+++ b/lib/utils/generateAuthUrl.ts
@@ -30,9 +30,9 @@ export const generateAuthUrl = async (
 
   if (!options.state) {
     options.state = generateRandomString(32);
-    if (activeStorage) {
-      activeStorage.setSessionItem(StorageKeys.state, options.state);
-    }
+  }
+  if (activeStorage) {
+    activeStorage.setSessionItem(StorageKeys.state, options.state);
   }
   searchParams["state"] = options.state;
 

--- a/lib/utils/isCustomDomain.test.ts
+++ b/lib/utils/isCustomDomain.test.ts
@@ -15,7 +15,7 @@ describe("isCustomDomain", () => {
     expect(result).toEqual(false);
   });
   it("works on no prod kinde domains", () => {
-    const result = isCustomDomain("https://stakesocial-dave.au.kinde.com");
+    const result = isCustomDomain("https://test-test.au.kinde.com");
     expect(result).toEqual(false);
   });
 });

--- a/lib/utils/isCustomDomain.test.ts
+++ b/lib/utils/isCustomDomain.test.ts
@@ -14,4 +14,8 @@ describe("isCustomDomain", () => {
     const result = isCustomDomain("test.kinde.com");
     expect(result).toEqual(false);
   });
+  it("works on no prod kinde domains", () => {
+    const result = isCustomDomain("https://stakesocial-dave.au.kinde.com");
+    expect(result).toEqual(false);
+  });
 });

--- a/lib/utils/isCustomDomain.ts
+++ b/lib/utils/isCustomDomain.ts
@@ -1,5 +1,5 @@
 export const isCustomDomain = (domain: string): boolean => {
   return !domain.match(
-    /^(?:https?:\/\/)?[a-zA-Z0-9][-a-zA-Z0-9]*\.kinde\.com$/i,
+    /^(?:https?:\/\/)?[a-zA-Z0-9][.-a-zA-Z0-9]*\.kinde\.com$/i,
   );
 };

--- a/lib/utils/token/refreshToken.ts
+++ b/lib/utils/token/refreshToken.ts
@@ -4,7 +4,7 @@ import {
   StorageKeys,
   storageSettings,
 } from "../../sessionManager";
-import { sanitizeUrl } from "..";
+import { isCustomDomain, sanitizeUrl } from "..";
 import { clearRefreshTimer, setRefreshTimer } from "../refreshTimer";
 
 export interface RefreshTokenResult {
@@ -51,7 +51,7 @@ export const refreshToken = async ({
     let refreshTokenValue: string = "";
 
     let storage: SessionManager | null;
-    if (storageSettings.useInsecureForRefreshToken) {
+    if (storageSettings.useInsecureForRefreshToken || !isCustomDomain(domain)) {
       storage = getInsecureStorage();
     } else {
       storage = getActiveStorage();
@@ -102,17 +102,27 @@ export const refreshToken = async ({
       }
       const data = await response.json();
       if (data.access_token) {
+        const secureStore = getActiveStorage();
+        if (!secureStore) {
+          return {
+            success: false,
+            error: "No active storage found",
+          };
+        }
         setRefreshTimer(data.expires_in, async () => {
           refreshToken({ domain, clientId });
         });
 
         if (storage) {
-          await storage.setSessionItem(
+          await secureStore.setSessionItem(
             StorageKeys.accessToken,
             data.access_token,
           );
           if (data.id_token) {
-            await storage.setSessionItem(StorageKeys.idToken, data.id_token);
+            await secureStore.setSessionItem(
+              StorageKeys.idToken,
+              data.id_token,
+            );
           }
           if (data.refresh_token) {
             await storage.setSessionItem(
@@ -142,7 +152,7 @@ export const refreshToken = async ({
   } catch (error) {
     return {
       success: false,
-      error: `Error refreshing token: ${error}`,
+      error: `Error refreshing token: ${(error as Error).message}`,
     };
   }
 };

--- a/lib/utils/token/refreshToken.ts
+++ b/lib/utils/token/refreshToken.ts
@@ -110,7 +110,7 @@ export const refreshToken = async ({
           };
         }
         setRefreshTimer(data.expires_in, async () => {
-          refreshToken({ domain, clientId });
+          refreshToken({ domain, clientId, refreshType });
         });
 
         if (storage) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.7.1",
+  "version": "0.7.2-5",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",


### PR DESCRIPTION
# Explain your changes

When using on non custom domain `useInsecureForRefreshToken` resulted in access and id token to be stored insecurely

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
