### PR TITLE
Stringify the body of the refresh token request

### DIFF
--- a/lib/utils/token/refreshToken.ts
+++ b/lib/utils/token/refreshToken.ts
@@ -92,7 +92,7 @@ export const refreshToken = async ({
           }),
           grant_type: "refresh_token",
           client_id: clientId,
-        }),
+        }).toString(),
       });
       if (!response.ok) {
         return {


### PR DESCRIPTION
# Explain your changes

Fixes an issue with refreshing a token by calling `refreshToken` from a native app. The URLSearchParameters being used in the body of the request need to be converted to a string before being used in the `fetch`, otherwise the fetch will send an empty body, which results in the `oauth/token` endpoint returning a 500 status. 

This behaviour was observed in an react native app on iOS. 

I've patched this change locally and confirmed that the fix resolves the issue.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
