### PR TITLE
feat: enhancements to codeExchange

### DIFF
--- a/lib/utils/exchangeAuthCode.test.ts
+++ b/lib/utils/exchangeAuthCode.test.ts
@@ -453,7 +453,10 @@ describe("exchangeAuthCode", () => {
         clientId: "test",
         redirectURL: "test.com",
       }),
-    ).rejects.toThrow("Fetch failed");
+    ).resolves.toEqual({
+      error: "Token exchange failed: Error: Fetch failed",
+      success: false,
+    });
   });
 
   it("should return error if token response is invalid", async () => {


### PR DESCRIPTION
# Explain your changes

Enhancements to the codeExchange method.

- Stop refresh timer earlier
- Check localStorage refresh token to correctly set the credentials
- Handle the fetch failure better and clear storage.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
