### PR TITLE
fix: long token expiry with refresh

### DIFF
--- a/lib/utils/refreshTimer.test.ts
+++ b/lib/utils/refreshTimer.test.ts
@@ -14,6 +14,14 @@ describe("refreshTimer", () => {
     expect(callback).not.toHaveBeenCalled();
   });
 
+  it("max refresh timer of 1 day", () => {
+    const callback = vi.fn();
+    const setTimeout = vi.spyOn(window, "setTimeout");
+    RefreshTimer.setRefreshTimer(10000000000, callback);
+    expect(setTimeout).toBeCalledWith(callback, 86400000);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
   it("error when timeout is negative", () => {
     const callback = vi.fn();
     expect(() => RefreshTimer.setRefreshTimer(-10, callback)).toThrowError(

--- a/lib/utils/refreshTimer.ts
+++ b/lib/utils/refreshTimer.ts
@@ -8,7 +8,10 @@ export function setRefreshTimer(timer: number, callback: () => void) {
   if (timer <= 0) {
     throw new Error("Timer duration must be positive");
   }
-  refreshTimer = window.setTimeout(callback, timer * 1000 - 10000);
+  refreshTimer = window.setTimeout(
+    callback,
+    Math.min(timer * 1000 - 10000, 86400000),
+  );
 }
 
 export function clearRefreshTimer() {


### PR DESCRIPTION
# Explain your changes

When token expiry is longer than 27 day, this will cause the refreshTimer to instantly resolve.  This forces the SDK to get a new token max every 24 hours.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
