### PR TITLE
feat: notify on token refresh after code exchange

### DIFF
--- a/lib/utils/exchangeAuthCode.ts
+++ b/lib/utils/exchangeAuthCode.ts
@@ -7,6 +7,7 @@ import {
 } from "../main";
 import { isCustomDomain } from ".";
 import { clearRefreshTimer, setRefreshTimer } from "./refreshTimer";
+import { RefreshTokenResult } from "./token/refreshToken";
 
 export const frameworkSettings: {
   framework: string;
@@ -24,6 +25,7 @@ interface ExchangeAuthCodeParams {
   clientId: string;
   redirectURL: string;
   autoRefresh?: boolean;
+  onRefresh?: (data: RefreshTokenResult) => void;
 }
 
 type ExchangeAuthCodeResultSuccess = {
@@ -62,6 +64,7 @@ export const exchangeAuthCode = async ({
   clientId,
   redirectURL,
   autoRefresh = false,
+  onRefresh,
 }: ExchangeAuthCodeParams): Promise<ExchangeAuthCodeResult> => {
   const state = urlParams.get("state");
   const code = urlParams.get("code");
@@ -185,7 +188,7 @@ export const exchangeAuthCode = async ({
 
   if (autoRefresh) {
     setRefreshTimer(data.expires_in, async () => {
-      refreshToken({ domain, clientId });
+      refreshToken({ domain, clientId, onRefresh });
     });
   }
 


### PR DESCRIPTION
# Explain your changes

After code exchange token refresh timer is started, this adds the callback to be consumed by SDKs and Engineers

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
