### PR TITLE
refactor: renamed generateProfileUrl to generatePortalUrl

### DIFF
--- a/lib/main.test.ts
+++ b/lib/main.test.ts
@@ -33,12 +33,14 @@ describe("index exports", () => {
       "Scopes",
       "StorageKeys",
       "RefreshType",
+      "PortalPage",
       "ProfilePage",
 
       // utils
       "base64UrlEncode",
       "extractAuthResults",
       "generateAuthUrl",
+      "generatePortalUrl",
       "generateProfileUrl",
       "generateRandomString",
       "mapLoginMethodParamsForUrl",

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -17,6 +17,7 @@ export {
   frameworkSettings,
   splitString,
   generateProfileUrl,
+  generatePortalUrl,
 } from "./utils";
 
 export {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -37,6 +37,19 @@ export type LoginMethodParams<T = Record<string, string>> = Partial<
   >
 >;
 
+export enum PortalPage {
+  organizationDetails = "organization_details",
+  organizationMembers = "organization_members",
+  organizationPlanDetails = "organization_plan_details",
+  organizationPaymentDetails = "organization_payment_details",
+  organizationPlanSelection = "organization_plan_selection",
+  profile = "profile",
+}
+
+/**
+ * @deprecated This enum is deprecated and will be removed in a future version.
+ * Please use `PortalPage` instead.
+ */
 export enum ProfilePage {
   organizationDetails = "organization_details",
   organizationMembers = "organization_members",
@@ -46,10 +59,10 @@ export enum ProfilePage {
   profile = "profile",
 }
 
-export type GenerateProfileUrlParams = {
+export type GeneratePortalUrlParams = {
   domain: string;
   returnUrl: string;
-  subNav?: ProfilePage;
+  subNav?: PortalPage;
 };
 
 export type KindeProperties = Partial<{

--- a/lib/utils/generatePortalUrl.test.ts
+++ b/lib/utils/generatePortalUrl.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import createFetchMock from "vitest-fetch-mock";
 import { generatePortalUrl, generateProfileUrl } from "./generatePortalUrl";
 import { MemoryStorage, StorageKeys } from "../sessionManager";
@@ -266,47 +266,5 @@ describe("generatePortalUrl", () => {
         subNav,
       }),
     ).rejects.toThrow("Failed to fetch profile URL: 500");
-  });
-});
-
-describe("generateProfileUrl", () => {
-  beforeEach(() => {
-    clearActiveStorage();
-    fetchMock.enableMocks();
-    fetchMock.resetMocks();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it("emits a console warning when called", async () => {
-    // Setup storage and mock response
-    const storage = new MemoryStorage();
-    setActiveStorage(storage);
-    await storage.setSessionItem(StorageKeys.accessToken, "storedAccessToken");
-
-    fetchMock.mockOnce(
-      JSON.stringify({
-        url: "http://responseurl",
-      }),
-    );
-
-    // Spy on console.warn
-    const warnSpy = vi.spyOn(console, "warn");
-
-    // Call the deprecated function
-    const domain = "https://mykindedomain.com";
-    const returnUrl = "http://somereturnurl.com";
-
-    await generateProfileUrl({
-      domain,
-      returnUrl,
-    });
-
-    // Verify the warning was emitted
-    expect(warnSpy).toHaveBeenCalledWith(
-      "Warning: generateProfileUrl is deprecated. Please use generatePortalUrl instead.",
-    );
   });
 });

--- a/lib/utils/generatePortalUrl.ts
+++ b/lib/utils/generatePortalUrl.ts
@@ -1,38 +1,58 @@
 import { StorageKeys } from "../sessionManager";
-import { GenerateProfileUrlParams, ProfilePage } from "../types";
+import { GeneratePortalUrlParams, PortalPage, ProfilePage } from "../types";
 import { sanitizeUrl } from "./sanitizeUrl";
 import { getActiveStorage } from "./token";
 
+/**
+ * @deprecated This function is deprecated and will be removed in a future version.
+ * Please use `generatePortalUrl` instead.
+ */
+export const generateProfileUrl = async (params: {
+  domain: string;
+  returnUrl: string;
+  subNav?: ProfilePage;
+}): Promise<{
+  url: URL;
+}> => {
+  console.warn(
+    "Warning: generateProfileUrl is deprecated. Please use generatePortalUrl instead.",
+  );
+  return generatePortalUrl({
+    domain: params.domain,
+    returnUrl: params.returnUrl,
+    subNav: params.subNav as unknown as PortalPage,
+  });
+};
 /**
  * Generates a URL to the user profile portal
  *
  * @param {Object} options - Configuration options
  * @param {string} options.domain - The domain of the Kinde instance
  * @param {string} options.returnUrl - URL to redirect to after completing the profile flow
- * @param {ProfilePage} options.subNav - Sub-navigation section to display
+ * @param {PortalPage} options.subNav - Sub-navigation section to display
  * @returns {Promise<{url: URL}>} Object containing the URL to redirect to
  */
-export const generateProfileUrl = async ({
+export const generatePortalUrl = async ({
   domain,
   returnUrl,
   subNav,
-}: GenerateProfileUrlParams): Promise<{
+}: GeneratePortalUrlParams): Promise<{
   url: URL;
 }> => {
   const activeStorage = getActiveStorage();
   if (!activeStorage) {
-    throw new Error("generateProfileUrl: Active storage not found");
+    throw new Error("generatePortalUrl: Active storage not found");
   }
 
   const token = (await activeStorage.getSessionItem(
     StorageKeys.accessToken,
   )) as string;
   if (!token) {
-    throw new Error("generateProfileUrl: Access Token not found");
+    throw new Error("generatePortalUrl: Access Token not found");
   }
 
   const params = new URLSearchParams({
-    sub_nav: subNav || ProfilePage.profile,
+    sub_nav: subNav || PortalPage.profile,
     return_url: returnUrl,
   });
 

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -9,4 +9,5 @@ export { checkAuth } from "./checkAuth";
 export { isCustomDomain } from "./isCustomDomain";
 export { setRefreshTimer, clearRefreshTimer } from "./refreshTimer";
 export { splitString } from "./splitString";
-export { generateProfileUrl } from "./generateProfileUrl";
+export { generatePortalUrl } from "./generatePortalUrl";
+export { generateProfileUrl } from "./generatePortalUrl";


### PR DESCRIPTION
# Explain your changes

This renamed the generateProfileUrl with generatePortalUrl to be more consistent with other language 

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
