### PR TITLE
fix: ensure absolute returnUrls are supplied to portal generation

### DIFF
--- a/lib/utils/generatePortalUrl.test.ts
+++ b/lib/utils/generatePortalUrl.test.ts
@@ -26,7 +26,7 @@ describe("generateProfileUrl", () => {
         url: "http://responseurl",
       }),
     );
-    generateProfileUrl({ domain });
+    generateProfileUrl({ domain, returnUrl: "http://returnurl.com" });
     expect(warnSpy).toHaveBeenCalledWith(
       "Warning: generateProfileUrl is deprecated. Please use generatePortalUrl instead.",
     );
@@ -266,5 +266,29 @@ describe("generatePortalUrl", () => {
         subNav,
       }),
     ).rejects.toThrow("Failed to fetch profile URL: 500");
+  });
+
+  it("Handles when the returnUrl is not absolute", async () => {
+    const storage = new MemoryStorage();
+    setActiveStorage(storage);
+    await storage.setSessionItem(StorageKeys.accessToken, "storedAccessToken");
+
+    fetchMock.mockOnce(
+      JSON.stringify({
+        url: "/tst",
+      }),
+    );
+
+    const domain = "https://mykindedomain.com";
+    const returnUrl = "somereturnurl.com";
+    const subNav: PortalPage = PortalPage.profile;
+
+    await expect(
+      generatePortalUrl({
+        domain,
+        returnUrl,
+        subNav,
+      }),
+    ).rejects.toThrow("generatePortalUrl: returnUrl must be an absolute URL");
   });
 });

--- a/lib/utils/generatePortalUrl.ts
+++ b/lib/utils/generatePortalUrl.ts
@@ -51,6 +51,10 @@ export const generatePortalUrl = async ({
     throw new Error("generatePortalUrl: Access Token not found");
   }
 
+  if (!returnUrl.startsWith("http")) {
+    throw new Error("generatePortalUrl: returnUrl must be an absolute URL");
+  }
+
   const params = new URLSearchParams({
     sub_nav: subNav || PortalPage.profile,
     return_url: returnUrl,


### PR DESCRIPTION
# Explain your changes

Ensure that returnUrls start with `http`

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
