### PR TITLE
feat: getPermissions hard check

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -275,3 +275,57 @@ export type BaseAccountResponse = {
   metadata: Metadata;
   data: unknown;
 };
+
+export type ApiEntitlement = {
+  id: string;
+  fixed_charge: number;
+  price_name: string;
+  unit_amount: number;
+  feature_key: string;
+  feature_name: string;
+  entitlement_limit_max: number;
+  entitlement_limit_min: number;
+};
+
+export type Entitlement = {
+  id: string;
+  fixedCharge: number;
+  priceName: string;
+  unitAmount: number;
+  featureKey: string;
+  featureName: string;
+  entitlementLimitMax: number;
+  entitlementLimitMin: number;
+};
+
+export type ApiGetEntitlementsResponse = {
+  org_code: string;
+  plans: ApiPlan[];
+  entitlements: ApiEntitlement[];
+};
+
+export type ApiGetEntitlementResponse = {
+  org_code: string;
+  entitlement: ApiEntitlement;
+};
+
+export type getEntitlementsResponse = {
+  orgCode: string;
+  plans: Plan[];
+  entitlements: Entitlement[];
+};
+
+export type getEntitlementResponse = {
+  orgCode: string;
+  entitlement: Entitlement;
+};
+
+export type Plan = {
+  key: string;
+  subscribedOn: string; // ISO date string
+};
+
+export type ApiPlan = {
+  key: string;
+  subscribed_on: string; // ISO date string
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -273,4 +273,5 @@ type Metadata = {
 
 export type BaseAccountResponse = {
   metadata: Metadata;
+  data: unknown;
 };

--- a/lib/utils/deepMerge.ts
+++ b/lib/utils/deepMerge.ts
@@ -1,0 +1,28 @@
+import { BaseAccountResponse } from "../types";
+
+export const deepMerge = <T extends BaseAccountResponse>(
+  obj1: T["data"],
+  obj2: T["data"],
+) => {
+  if (Array.isArray(obj1) && Array.isArray(obj2)) {
+    return Array.from(new Set([...obj1, ...obj2]));
+  } else if (
+    obj1 &&
+    typeof obj1 === "object" &&
+    obj2 &&
+    typeof obj2 === "object"
+  ) {
+    const merged = { ...obj1 };
+    for (const key of Object.keys(obj2)) {
+      if (key in merged) {
+        //@ts-expect-error // TypeScript doesn't know merged[key] is an object
+        merged[key] = deepMerge(merged[key], obj2[key]);
+      } else {
+        //@ts-expect-error // TypeScript doesn't know merged[key] is an object
+        merged[key] = obj2[key];
+      }
+    }
+    return merged;
+  }
+  return obj2;
+};

--- a/lib/utils/token/getEntitlement.ts
+++ b/lib/utils/token/getEntitlement.ts
@@ -1,0 +1,37 @@
+import {
+  BaseAccountResponse,
+  ApiGetEntitlementResponse,
+  getEntitlementResponse,
+} from "../../types";
+import { callAccountApi } from "./accountApi/callAccountApi";
+
+/**
+ * Fetches entitlements from the account API.
+ * @returns {Promise<{ name: keyof T; value: V } | EntitlementsResponse>}
+ * @template T - Type of the decoded JWT.
+ * @template V - Type of the entitlement value.
+ */
+export const getEntitlement = async (
+  key: string,
+): Promise<getEntitlementResponse> => {
+  const response = await callAccountApi<EntitlementResponse>(
+    `account_api/v1/entitlement/${encodeURIComponent(key)}`,
+  );
+  return {
+    orgCode: response.data.org_code,
+    entitlement: {
+      id: response.data.entitlement.id,
+      fixedCharge: response.data.entitlement.fixed_charge,
+      priceName: response.data.entitlement.price_name,
+      unitAmount: response.data.entitlement.unit_amount,
+      featureKey: response.data.entitlement.feature_key,
+      featureName: response.data.entitlement.feature_name,
+      entitlementLimitMax: response.data.entitlement.entitlement_limit_max,
+      entitlementLimitMin: response.data.entitlement.entitlement_limit_min,
+    },
+  };
+};
+
+type EntitlementResponse = BaseAccountResponse & {
+  data: ApiGetEntitlementResponse;
+};

--- a/lib/utils/token/getEntitlement.ts
+++ b/lib/utils/token/getEntitlement.ts
@@ -5,11 +5,14 @@ import {
 } from "../../types";
 import { callAccountApi } from "./accountApi/callAccountApi";
 
+type EntitlementResponse = BaseAccountResponse & {
+  data: ApiGetEntitlementResponse;
+};
+
 /**
- * Fetches entitlements from the account API.
- * @returns {Promise<{ name: keyof T; value: V } | EntitlementsResponse>}
- * @template T - Type of the decoded JWT.
- * @template V - Type of the entitlement value.
+ * Fetches a single entitlement from the account API.
+ * @param key - The entitlement key to fetch
+ * @returns {Promise<{ name: keyof T; value: V } | EntitlementResponse>}
  */
 export const getEntitlement = async (
   key: string,
@@ -30,8 +33,4 @@ export const getEntitlement = async (
       entitlementLimitMin: response.data.entitlement.entitlement_limit_min,
     },
   };
-};
-
-type EntitlementResponse = BaseAccountResponse & {
-  data: ApiGetEntitlementResponse;
 };

--- a/lib/utils/token/getEntitlements.ts
+++ b/lib/utils/token/getEntitlements.ts
@@ -1,5 +1,11 @@
-import { BaseAccountResponse } from "../../types";
-import { callAccountApi } from "./accountApi/callAccountApi";
+import {
+  BaseAccountResponse,
+  ApiEntitlement,
+  ApiPlan,
+  getEntitlementsResponse,
+  ApiGetEntitlementsResponse,
+} from "../../types";
+import { callAccountApiPaginated } from "./accountApi/callAccountApi";
 
 /**
  * Fetches entitlements from the account API.
@@ -8,64 +14,28 @@ import { callAccountApi } from "./accountApi/callAccountApi";
  * @template V - Type of the entitlement value.
  */
 export const getEntitlements = async (): Promise<getEntitlementsResponse> => {
-  const response = await callAccountApi<EntitlementsResponse>(
-    "account_api/v1/entitlements",
-  );
+  const response = await callAccountApiPaginated<EntitlementsResponse>({
+    url: "account_api/v1/entitlements",
+  });
   return {
-    orgCode: response.data.org_code,
-    plans: response.data.plans.map((plan: ApiPlan) => ({
+    orgCode: response.org_code,
+    plans: response.plans.map((plan: ApiPlan) => ({
       key: plan.key,
       subscribedOn: plan.subscribed_on,
     })),
-    entitlements: response.data.entitlements.map(
-      (entitlement: ApiEntitlement) => ({
-        id: entitlement.id,
-        fixedCharge: entitlement.fixed_charge,
-        priceName: entitlement.price_name,
-        unitAmount: entitlement.unit_amount,
-        featureKey: entitlement.feature_key,
-        featureName: entitlement.feature_name,
-        entitlementLimitMax: entitlement.entitlement_limit_max,
-        entitlementLimitMin: entitlement.entitlement_limit_min,
-      }),
-    ),
+    entitlements: response.entitlements.map((entitlement: ApiEntitlement) => ({
+      id: entitlement.id,
+      fixedCharge: entitlement.fixed_charge,
+      priceName: entitlement.price_name,
+      unitAmount: entitlement.unit_amount,
+      featureKey: entitlement.feature_key,
+      featureName: entitlement.feature_name,
+      entitlementLimitMax: entitlement.entitlement_limit_max,
+      entitlementLimitMin: entitlement.entitlement_limit_min,
+    })),
   };
 };
 
-type getEntitlementsResponse = {
-  orgCode: string;
-  plans: Plan[];
-  entitlements: Entitlement[];
-};
-
-type Entitlement = {
-  id: string;
-  fixedCharge: number;
-  priceName: string;
-  unitAmount: number;
-  featureKey: string;
-  featureName: string;
-  entitlementLimitMax: number;
-  entitlementLimitMin: number;
-};
-
-type ApiEntitlement = {
-  id: string;
-  fixed_charge: number;
-  price_name: string;
-  unit_amount: number;
-  feature_key: string;
-  feature_name: string;
-  entitlement_limit_max: number;
-  entitlement_limit_min: number;
-};
-
-type ApiPlan = {
-  key: string;
-  subscribed_on: string; // ISO date string
-};
-
-type Plan = {
-  key: string;
-  subscribedOn: string; // ISO date string
+type EntitlementsResponse = BaseAccountResponse & {
+  data: ApiGetEntitlementsResponse;
 };

--- a/lib/utils/token/getEntitlements.ts
+++ b/lib/utils/token/getEntitlements.ts
@@ -1,3 +1,4 @@
+import { BaseAccountResponse } from "../../types";
 import { callAccountApi } from "./accountApi/callAccountApi";
 
 /**
@@ -12,20 +13,22 @@ export const getEntitlements = async (): Promise<getEntitlementsResponse> => {
   );
   return {
     orgCode: response.data.org_code,
-    plans: response.data.plans.map((plan) => ({
+    plans: response.data.plans.map((plan: ApiPlan) => ({
       key: plan.key,
       subscribedOn: plan.subscribed_on,
     })),
-    entitlements: response.data.entitlements.map((entitlement) => ({
-      id: entitlement.id,
-      fixedCharge: entitlement.fixed_charge,
-      priceName: entitlement.price_name,
-      unitAmount: entitlement.unit_amount,
-      featureKey: entitlement.feature_key,
-      featureName: entitlement.feature_name,
-      entitlementLimitMax: entitlement.entitlement_limit_max,
-      entitlementLimitMin: entitlement.entitlement_limit_min,
-    })),
+    entitlements: response.data.entitlements.map(
+      (entitlement: ApiEntitlement) => ({
+        id: entitlement.id,
+        fixedCharge: entitlement.fixed_charge,
+        priceName: entitlement.price_name,
+        unitAmount: entitlement.unit_amount,
+        featureKey: entitlement.feature_key,
+        featureName: entitlement.feature_name,
+        entitlementLimitMax: entitlement.entitlement_limit_max,
+        entitlementLimitMin: entitlement.entitlement_limit_min,
+      }),
+    ),
   };
 };
 
@@ -65,20 +68,4 @@ type ApiPlan = {
 type Plan = {
   key: string;
   subscribedOn: string; // ISO date string
-};
-
-type Data = {
-  org_code: string;
-  plans: ApiPlan[];
-  entitlements: ApiEntitlement[];
-};
-
-type Metadata = {
-  has_more: boolean;
-  next_page_starting_after: string;
-};
-
-type EntitlementsResponse = {
-  data: Data;
-  metadata: Metadata;
 };

--- a/lib/utils/token/getEntitlements.ts
+++ b/lib/utils/token/getEntitlements.ts
@@ -7,11 +7,13 @@ import {
 } from "../../types";
 import { callAccountApiPaginated } from "./accountApi/callAccountApi";
 
+export type EntitlementsResponse = BaseAccountResponse & {
+  data: ApiGetEntitlementsResponse;
+};
+
 /**
  * Fetches entitlements from the account API.
  * @returns {Promise<{ name: keyof T; value: V } | EntitlementsResponse>}
- * @template T - Type of the decoded JWT.
- * @template V - Type of the entitlement value.
  */
 export const getEntitlements = async (): Promise<getEntitlementsResponse> => {
   const response = await callAccountApiPaginated<EntitlementsResponse>({
@@ -34,8 +36,4 @@ export const getEntitlements = async (): Promise<getEntitlementsResponse> => {
       entitlementLimitMin: entitlement.entitlement_limit_min,
     })),
   };
-};
-
-type EntitlementsResponse = BaseAccountResponse & {
-  data: ApiGetEntitlementsResponse;
 };

--- a/lib/utils/token/getPermission.ts
+++ b/lib/utils/token/getPermission.ts
@@ -19,7 +19,7 @@ export const getPermission = async <T = string>(
 ): Promise<PermissionAccess> => {
   if (options?.forceApi) {
     return callAccountApi<PermissionAccess>(
-      `account_api/v1/permission/${permissionKey}`,
+      `account_api/v1/permission/${encodeURIComponent(permissionKey as string)}`,
     );
   }
 

--- a/lib/utils/token/getPermission.ts
+++ b/lib/utils/token/getPermission.ts
@@ -1,4 +1,6 @@
 import { getDecodedToken } from ".";
+import { GetPermissionOptions } from "../../types";
+import { callAccountApi } from "./accountApi/callAccountApi";
 
 export type PermissionAccess = {
   permissionKey: string;
@@ -13,7 +15,14 @@ export type PermissionAccess = {
  */
 export const getPermission = async <T = string>(
   permissionKey: T,
+  options?: GetPermissionOptions,
 ): Promise<PermissionAccess> => {
+  if (options?.forceApi) {
+    return callAccountApi<PermissionAccess>(
+      `account_api/v1/permission/${permissionKey}`,
+    );
+  }
+
   const token = await getDecodedToken();
 
   if (!token) {

--- a/lib/utils/token/getPermissions.test.ts
+++ b/lib/utils/token/getPermissions.test.ts
@@ -1,18 +1,25 @@
-import { describe, expect, it, beforeEach } from "vitest";
+import { vi, describe, expect, it, beforeEach, afterEach } from "vitest";
 import { MemoryStorage, StorageKeys } from "../../sessionManager";
 import { setActiveStorage } from ".";
 import { createMockAccessToken } from "./testUtils";
 import { getPermissions } from ".";
-
-const storage = new MemoryStorage();
+import createFetchMock from "vitest-fetch-mock";
 
 enum PermissionEnum {
   canEdit = "canEdit",
 }
 
+const fetchMock = createFetchMock(vi);
+const storage = new MemoryStorage();
+
 describe("getPermissions", () => {
   beforeEach(() => {
     setActiveStorage(storage);
+    fetchMock.enableMocks();
+  });
+
+  afterEach(() => {
+    fetchMock.resetMocks();
   });
 
   it("when no token", async () => {
@@ -61,6 +68,96 @@ describe("getPermissions", () => {
     expect(idToken).toStrictEqual({
       orgCode: "org_123456789",
       permissions: [],
+    });
+  });
+
+  it("when hardCheck is true, calls account API", async () => {
+    await storage.setSessionItem(
+      StorageKeys.accessToken,
+      createMockAccessToken({ permissions: null }),
+    );
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        data: {
+          org_code: "org_0195ac80a14e",
+          permissions: [
+            {
+              id: "perm_0195ac80a14e8d71f42b98e75d3c61ad",
+              name: "View reports",
+              key: "view_reports",
+            },
+          ],
+        },
+        metadata: {
+          has_more: false,
+          next_page_starting_after: "perm_0195ac80a14e8d71f42b98e75d3c61ad",
+        },
+      }),
+    );
+
+    const permissions = await getPermissions({ forceApi: true });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://kinde.com/account_api/v1/permissions",
+      expect.anything(),
+    );
+    expect(permissions).toStrictEqual({
+      orgCode: "org_0195ac80a14e",
+      permissions: ["view_reports"],
+    });
+  });
+
+  it("when hardCheck is true, calls account API - multiple pages", async () => {
+    await storage.setSessionItem(
+      StorageKeys.accessToken,
+      createMockAccessToken({ permissions: null }),
+    );
+    fetchMock
+      .mockResponseOnce(
+        JSON.stringify({
+          data: {
+            org_code: "org_0195ac80a14e",
+            permissions: [
+              {
+                id: "perm_0195ac80a14e8d71f42b98e75d3c61ad",
+                name: "View reports",
+                key: "view_reports",
+              },
+            ],
+          },
+          metadata: {
+            has_more: true,
+            next_page_starting_after: "perm_0195ac80a14e8d71f42b98e75d3c61ad",
+          },
+        }),
+      )
+      .mockResponseOnce(
+        JSON.stringify({
+          data: {
+            org_code: "org_0195ac80a14e",
+            permissions: [
+              {
+                id: "perm_0195ac80a14e8d71f42b98e75d3c6112",
+                name: "View bills",
+                key: "view_bills",
+              },
+            ],
+          },
+          metadata: {
+            has_more: false,
+            next_page_starting_after: "perm_0195ac80a14e8d71f42b98e75d3c6112",
+          },
+        }),
+      );
+    const permissions = await getPermissions({ forceApi: true });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://kinde.com/account_api/v1/permissions",
+      expect.anything(),
+    );
+    expect(permissions).toStrictEqual({
+      orgCode: "org_0195ac80a14e",
+      permissions: ["view_reports", "view_bills"],
     });
   });
 });

--- a/lib/utils/token/getPermissions.ts
+++ b/lib/utils/token/getPermissions.ts
@@ -1,11 +1,33 @@
 import { getDecodedToken } from ".";
+import { BaseAccountResponse, GetPermissionsOptions } from "../../types";
+import { callAccountApiPaginated } from "./accountApi/callAccountApi";
+
+type AccountPermissionsResult = BaseAccountResponse & {
+  data: {
+    org_code: string;
+    permissions: { id: string; name: string; key: string }[];
+  };
+};
 
 export type Permissions<T> = { orgCode: string | null; permissions: T[] };
 /**
  * Get all permissions
  * @returns { Promise<Permissions> }
  */
-export const getPermissions = async <T = string>(): Promise<Permissions<T>> => {
+export const getPermissions = async <T = string>(
+  options?: GetPermissionsOptions,
+): Promise<Permissions<T>> => {
+  if (options?.forceApi) {
+    const data = await callAccountApiPaginated<AccountPermissionsResult>({
+      url: `account_api/v1/permissions`,
+    });
+
+    return {
+      orgCode: data.org_code,
+      permissions: data.permissions.map((permission) => permission.key) as T[],
+    };
+  }
+
   const token = await getDecodedToken();
 
   if (!token) {


### PR DESCRIPTION
# Explain your changes

Adds an additional parameter to the getPermissions which is an object of options.  Currently there is a single option which takes `forceApi` as a property.

When this is set to `true` it will not look at the token and will use the account API to check the permission for the user.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
