### PR TITLE
feat: add automatic activity tracking with session expiry

### DIFF
--- a/lib/main.test.ts
+++ b/lib/main.test.ts
@@ -55,6 +55,8 @@ describe("index exports", () => {
       "splitString",
       "generateKindeSDKHeader",
       "navigateToKinde",
+      "createMiddlewareActivityProxy",
+      "ActivityExpiredError",
 
       // session manager
       "MemoryStorage",

--- a/lib/main.test.ts
+++ b/lib/main.test.ts
@@ -55,8 +55,8 @@ describe("index exports", () => {
       "splitString",
       "generateKindeSDKHeader",
       "navigateToKinde",
-      "createMiddlewareActivityProxy",
-      "ActivityExpiredError",
+      "updateActivityTimestamp",
+      "sessionManagerActivityProxy",
 
       // session manager
       "MemoryStorage",

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -20,6 +20,8 @@ export {
   generatePortalUrl,
   generateKindeSDKHeader,
   navigateToKinde,
+  createMiddlewareActivityProxy,
+  ActivityExpiredError,
 } from "./utils";
 
 export {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -20,7 +20,8 @@ export {
   generatePortalUrl,
   generateKindeSDKHeader,
   navigateToKinde,
-  ActivityExpiredError,
+  updateActivityTimestamp,
+  sessionManagerActivityProxy,
 } from "./utils";
 
 export {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -20,7 +20,6 @@ export {
   generatePortalUrl,
   generateKindeSDKHeader,
   navigateToKinde,
-  createMiddlewareActivityProxy,
   ActivityExpiredError,
 } from "./utils";
 

--- a/lib/sessionManager/index.ts
+++ b/lib/sessionManager/index.ts
@@ -25,6 +25,20 @@ export const storageSettings: StorageSettingsType = {
    * When undefined, activity tracking is disabled.
    */
   activityTimeoutMinutes: undefined,
+
+  /**
+   * The number of minutes of inactivity before a pre-warning is shown.
+   *
+   * When undefined, pre-warning is disabled.
+   */
+  activityTimeoutPreWarningMinutes: undefined,
+
+  /**
+   * The function to call when the activity timeout is reached.
+   *
+   * @param timeoutType - The type of timeout that occurred.   
+   */
+  onActivityTimeout: undefined,
 };
 
 // Export session manager related items directly

--- a/lib/sessionManager/index.ts
+++ b/lib/sessionManager/index.ts
@@ -18,6 +18,13 @@ export const storageSettings: StorageSettingsType = {
    * Warning: This should only be used when you're not using a custom domain and no backend app to authenticate on.
    */
   useInsecureForRefreshToken: false,
+
+  /**
+   * The number of minutes of inactivity before tokens are considered expired.
+   *
+   * When undefined, activity tracking is disabled.
+   */
+  activityTimeoutMinutes: undefined,
 };
 
 // Export session manager related items directly

--- a/lib/sessionManager/index.ts
+++ b/lib/sessionManager/index.ts
@@ -36,7 +36,7 @@ export const storageSettings: StorageSettingsType = {
   /**
    * The function to call when the activity timeout is reached.
    *
-   * @param timeoutType - The type of timeout that occurred.   
+   * @param timeoutType - The type of timeout that occurred.
    */
   onActivityTimeout: undefined,
 };

--- a/lib/sessionManager/types.ts
+++ b/lib/sessionManager/types.ts
@@ -15,11 +15,20 @@ export enum StorageKeys {
   lastActivity = "lastActivity",
 }
 
+export enum TimeoutActivityType {
+  preWarning = "preWarning",
+  timeout = "timeout",
+}
+
 export type StorageSettingsType = {
   keyPrefix: string;
   maxLength: number;
   useInsecureForRefreshToken: boolean;
   activityTimeoutMinutes?: number;
+  activityTimeoutPreWarningMinutes?: number;
+  onActivityTimeout?: (
+    timeoutType: TimeoutActivityType,
+  ) => void | Promise<void>;
 };
 
 export abstract class SessionBase<V extends string = StorageKeys>

--- a/lib/sessionManager/types.ts
+++ b/lib/sessionManager/types.ts
@@ -12,7 +12,6 @@ export enum StorageKeys {
   state = "state",
   nonce = "nonce",
   codeVerifier = "codeVerifier",
-  lastActivity = "lastActivity",
 }
 
 export enum TimeoutActivityType {

--- a/lib/sessionManager/types.ts
+++ b/lib/sessionManager/types.ts
@@ -12,12 +12,14 @@ export enum StorageKeys {
   state = "state",
   nonce = "nonce",
   codeVerifier = "codeVerifier",
+  lastActivity = "lastActivity",
 }
 
 export type StorageSettingsType = {
   keyPrefix: string;
   maxLength: number;
   useInsecureForRefreshToken: boolean;
+  activityTimeoutMinutes?: number;
 };
 
 export abstract class SessionBase<V extends string = StorageKeys>

--- a/lib/sessionManager/types.ts
+++ b/lib/sessionManager/types.ts
@@ -24,6 +24,9 @@ export type StorageSettingsType = {
   maxLength: number;
   useInsecureForRefreshToken: boolean;
   activityTimeoutMinutes?: number;
+  /**
+   * Pre-warning in minutes. MUST be less than activityTimeoutMinutes when set.
+   */
   activityTimeoutPreWarningMinutes?: number;
   onActivityTimeout?: (
     timeoutType: TimeoutActivityType,

--- a/lib/utils/activityTracking.test.ts
+++ b/lib/utils/activityTracking.test.ts
@@ -69,7 +69,7 @@ describe("Activity Tracking", () => {
       const activeStorage = getActiveStorage()!;
 
       await activeStorage.getSessionItem(StorageKeys.accessToken);
-      
+
       // Advance time and wait for async operations to complete
       await vi.advanceTimersByTimeAsync(30 * 60 * 1000 + 1000);
 

--- a/lib/utils/activityTracking.test.ts
+++ b/lib/utils/activityTracking.test.ts
@@ -110,7 +110,7 @@ describe("Activity Tracking", () => {
       await activeStorage.getSessionItem(StorageKeys.accessToken);
       vi.advanceTimersByTime(30 * 60 * 1000 + 1000);
 
-      expect(destroySpy).toHaveBeenCalledTimes(2);
+      expect(destroySpy).toHaveBeenCalledTimes(1);
       expect(mockOnActivityTimeout).toHaveBeenCalledWith(
         TimeoutActivityType.timeout,
       );

--- a/lib/utils/activityTracking.test.ts
+++ b/lib/utils/activityTracking.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { storageSettings } from "../sessionManager/index.js";
+import { StorageKeys } from "../sessionManager/types.js";
+import { MemoryStorage } from "../sessionManager/stores/memory.js";
+import {
+  createMiddlewareActivityProxy,
+  ActivityExpiredError,
+} from "./activityTracking.js";
+
+describe("Activity Tracking", () => {
+  let sessionManager: MemoryStorage<string>;
+  let originalTimeoutMinutes: number | undefined;
+  let originalKeyPrefix: string;
+
+  beforeEach(() => {
+    sessionManager = new MemoryStorage<string>();
+    originalTimeoutMinutes = storageSettings.activityTimeoutMinutes;
+    originalKeyPrefix = storageSettings.keyPrefix;
+    storageSettings.activityTimeoutMinutes = undefined;
+    storageSettings.keyPrefix = "test_";
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    storageSettings.activityTimeoutMinutes = originalTimeoutMinutes;
+    storageSettings.keyPrefix = originalKeyPrefix;
+  });
+
+  const getLastActivity = async () => {
+    const activityKey = `${storageSettings.keyPrefix}${StorageKeys.lastActivity}`;
+    const value = await sessionManager.getSessionItem(activityKey as string);
+    if (!value) return null;
+
+    let timestamp: number;
+    if (typeof value === "string") {
+      timestamp = parseInt(value, 10);
+    } else if (typeof value === "number") {
+      timestamp = value;
+    } else {
+      return null;
+    }
+
+    return isNaN(timestamp) ? null : timestamp;
+  };
+
+  describe("createMiddlewareActivityProxy", () => {
+    it("should return original session manager when activity tracking is disabled", () => {
+      storageSettings.activityTimeoutMinutes = undefined;
+
+      const proxy = createMiddlewareActivityProxy(sessionManager);
+
+      expect(proxy).toBe(sessionManager);
+    });
+
+    it("should throw ActivityExpiredError when session is expired on getSessionItem", async () => {
+      storageSettings.activityTimeoutMinutes = 30;
+      const mockTime = 1000000;
+      vi.spyOn(Date, "now").mockReturnValue(mockTime);
+
+      // Set an old activity timestamp directly using prefixed key
+      const activityKey = `${storageSettings.keyPrefix}${StorageKeys.lastActivity}`;
+      await sessionManager.setSessionItem(
+        activityKey as string,
+        mockTime.toString(),
+      );
+
+      // Move time forward beyond timeout
+      vi.spyOn(Date, "now").mockReturnValue(mockTime + 45 * 60 * 1000);
+
+      const proxy = createMiddlewareActivityProxy(sessionManager);
+
+      await expect(proxy.getSessionItem("accessToken")).rejects.toThrow(
+        ActivityExpiredError,
+      );
+    });
+
+    it("should throw ActivityExpiredError when session is expired on setSessionItem", async () => {
+      storageSettings.activityTimeoutMinutes = 30;
+      const mockTime = 1000000;
+      vi.spyOn(Date, "now").mockReturnValue(mockTime);
+
+      // Set an old activity timestamp directly using prefixed key
+      const activityKey = `${storageSettings.keyPrefix}${StorageKeys.lastActivity}`;
+      await sessionManager.setSessionItem(
+        activityKey as string,
+        mockTime.toString(),
+      );
+
+      // Move time forward beyond timeout
+      vi.spyOn(Date, "now").mockReturnValue(mockTime + 45 * 60 * 1000);
+
+      const proxy = createMiddlewareActivityProxy(sessionManager);
+
+      await expect(
+        proxy.setSessionItem("accessToken", "token123"),
+      ).rejects.toThrow(ActivityExpiredError);
+    });
+
+    it("should update activity timestamp on successful getSessionItem", async () => {
+      storageSettings.activityTimeoutMinutes = 30;
+      const startTime = 1000000;
+      vi.spyOn(Date, "now").mockReturnValue(startTime);
+
+      const proxy = createMiddlewareActivityProxy(sessionManager);
+
+      // Set initial data
+      await sessionManager.setSessionItem("accessToken", "token123");
+
+      // Move time forward but within timeout
+      const laterTime = startTime + 10 * 60 * 1000;
+      vi.spyOn(Date, "now").mockReturnValue(laterTime);
+
+      await proxy.getSessionItem("accessToken");
+
+      const lastActivity = await getLastActivity();
+      expect(lastActivity).toBe(laterTime);
+    });
+
+    it("should update activity timestamp on successful setSessionItem", async () => {
+      storageSettings.activityTimeoutMinutes = 30;
+      const startTime = 1000000;
+      vi.spyOn(Date, "now").mockReturnValue(startTime);
+
+      const proxy = createMiddlewareActivityProxy(sessionManager);
+
+      // Move time forward
+      const laterTime = startTime + 10 * 60 * 1000;
+      vi.spyOn(Date, "now").mockReturnValue(laterTime);
+
+      await proxy.setSessionItem("accessToken", "token123");
+
+      const lastActivity = await getLastActivity();
+      expect(lastActivity).toBe(laterTime);
+    });
+
+    it("should pass through other methods without tracking", async () => {
+      storageSettings.activityTimeoutMinutes = 30;
+      const proxy = createMiddlewareActivityProxy(sessionManager);
+
+      await expect(proxy.destroySession()).resolves.not.toThrow();
+      await expect(proxy.removeSessionItem("someKey")).resolves.not.toThrow();
+    });
+
+    it("should handle fresh session (no activity) without throwing", async () => {
+      storageSettings.activityTimeoutMinutes = 30;
+      const proxy = createMiddlewareActivityProxy(sessionManager);
+
+      // Fresh session - should not throw and should update activity
+      const result = await proxy.getSessionItem("accessToken");
+      expect(result).toBeNull();
+
+      const lastActivity = await getLastActivity();
+      expect(lastActivity).toBeTruthy();
+    });
+
+    it("should throw ActivityExpiredError for invalid timestamp", async () => {
+      storageSettings.activityTimeoutMinutes = 30;
+
+      // Set invalid timestamp using the prefixed key that our implementation uses
+      const activityKey = `${storageSettings.keyPrefix}${StorageKeys.lastActivity}`;
+      await sessionManager.setSessionItem(
+        activityKey as string,
+        "invalid-timestamp",
+      );
+
+      const proxy = createMiddlewareActivityProxy(sessionManager);
+
+      await expect(proxy.getSessionItem("accessToken")).rejects.toThrow(
+        ActivityExpiredError,
+      );
+    });
+
+    it("should clean up activity data when session expires", async () => {
+      storageSettings.activityTimeoutMinutes = 30;
+      const mockTime = 1000000;
+      vi.spyOn(Date, "now").mockReturnValue(mockTime);
+
+      const activityKey = `${storageSettings.keyPrefix}${StorageKeys.lastActivity}`;
+      await sessionManager.setSessionItem(
+        activityKey as string,
+        mockTime.toString(),
+      );
+
+      // Verify activity data exists
+      let activityValue = await getLastActivity();
+      expect(activityValue).toBe(mockTime);
+
+      // Move time forward beyond timeout
+      vi.spyOn(Date, "now").mockReturnValue(mockTime + 45 * 60 * 1000);
+
+      const proxy = createMiddlewareActivityProxy(sessionManager);
+
+      // Should throw and clean up activity data
+      await expect(proxy.getSessionItem("accessToken")).rejects.toThrow(
+        ActivityExpiredError,
+      );
+
+      // Verify activity data was cleaned up
+      activityValue = await getLastActivity();
+      expect(activityValue).toBeNull();
+    });
+
+    it("should clean up activity data when invalid timestamp detected", async () => {
+      storageSettings.activityTimeoutMinutes = 30;
+
+      const activityKey = `${storageSettings.keyPrefix}${StorageKeys.lastActivity}`;
+      await sessionManager.setSessionItem(
+        activityKey as string,
+        "invalid-timestamp",
+      );
+
+      // Verify invalid activity data exists
+      const rawValue = await sessionManager.getSessionItem(
+        activityKey as string,
+      );
+      expect(rawValue).toBe("invalid-timestamp");
+
+      const proxy = createMiddlewareActivityProxy(sessionManager);
+
+      // Should throw and clean up activity data
+      await expect(proxy.getSessionItem("accessToken")).rejects.toThrow(
+        ActivityExpiredError,
+      );
+
+      // Verify activity data was cleaned up
+      const cleanedValue = await sessionManager.getSessionItem(
+        activityKey as string,
+      );
+      expect(cleanedValue).toBeNull();
+    });
+  });
+});

--- a/lib/utils/activityTracking.test.ts
+++ b/lib/utils/activityTracking.test.ts
@@ -3,7 +3,6 @@ import { storageSettings } from "../sessionManager/index.js";
 import { StorageKeys } from "../sessionManager/types.js";
 import { MemoryStorage } from "../sessionManager/stores/memory.js";
 import {
-  createMiddlewareActivityProxy,
   ActivityExpiredError,
 } from "./activityTracking.js";
 
@@ -47,7 +46,7 @@ describe("Activity Tracking", () => {
     it("should return original session manager when activity tracking is disabled", () => {
       storageSettings.activityTimeoutMinutes = undefined;
 
-      const proxy = createMiddlewareActivityProxy(sessionManager);
+      const proxy = getActiveStorage();
 
       expect(proxy).toBe(sessionManager);
     });

--- a/lib/utils/activityTracking.test.ts
+++ b/lib/utils/activityTracking.test.ts
@@ -69,7 +69,9 @@ describe("Activity Tracking", () => {
       const activeStorage = getActiveStorage()!;
 
       await activeStorage.getSessionItem(StorageKeys.accessToken);
-      vi.advanceTimersByTime(30 * 60 * 1000 + 1000);
+      
+      // Advance time and wait for async operations to complete
+      await vi.advanceTimersByTimeAsync(30 * 60 * 1000 + 1000);
 
       expect(mockOnActivityTimeout).toHaveBeenCalledWith(
         TimeoutActivityType.timeout,
@@ -93,7 +95,7 @@ describe("Activity Tracking", () => {
       vi.advanceTimersByTime(15 * 60 * 1000);
       expect(mockOnActivityTimeout).not.toHaveBeenCalled();
 
-      vi.advanceTimersByTime(15 * 60 * 1000 + 1000);
+      await vi.advanceTimersByTimeAsync(15 * 60 * 1000 + 1000);
       expect(mockOnActivityTimeout).toHaveBeenCalledWith(
         TimeoutActivityType.timeout,
       );
@@ -108,7 +110,7 @@ describe("Activity Tracking", () => {
       const destroySpy = vi.spyOn(sessionManager, "destroySession");
 
       await activeStorage.getSessionItem(StorageKeys.accessToken);
-      vi.advanceTimersByTime(30 * 60 * 1000 + 1000);
+      await vi.advanceTimersByTimeAsync(30 * 60 * 1000 + 1000);
 
       expect(destroySpy).toHaveBeenCalledTimes(1);
       expect(mockOnActivityTimeout).toHaveBeenCalledWith(
@@ -130,7 +132,7 @@ describe("Activity Tracking", () => {
       );
       expect(mockOnActivityTimeout).toHaveBeenCalledTimes(1);
 
-      vi.advanceTimersByTime(5 * 60 * 1000);
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
       expect(mockOnActivityTimeout).toHaveBeenCalledWith(
         TimeoutActivityType.timeout,
       );
@@ -190,13 +192,13 @@ describe("Activity Tracking", () => {
   });
 
   describe("updateActivityTimestamp", () => {
-    it("should start timeout timer when called", () => {
+    it("should start timeout timer when called", async () => {
       storageSettings.activityTimeoutMinutes = 30;
       setActiveStorage(sessionManager);
 
       updateActivityTimestamp();
 
-      vi.advanceTimersByTime(30 * 60 * 1000 + 1000);
+      await vi.advanceTimersByTimeAsync(30 * 60 * 1000 + 1000);
       expect(mockOnActivityTimeout).toHaveBeenCalledWith(
         TimeoutActivityType.timeout,
       );
@@ -244,7 +246,7 @@ describe("Activity Tracking", () => {
         activeStorage.getSessionItem(StorageKeys.accessToken),
       ).rejects.toThrow("Storage failed");
 
-      vi.advanceTimersByTime(30 * 60 * 1000 + 1000);
+      await vi.advanceTimersByTimeAsync(30 * 60 * 1000 + 1000);
       expect(mockOnActivityTimeout).toHaveBeenCalledWith(
         TimeoutActivityType.timeout,
       );

--- a/lib/utils/activityTracking.ts
+++ b/lib/utils/activityTracking.ts
@@ -1,4 +1,4 @@
-import { getActiveStorage, getInsecureStorage } from "../main.js";
+import { getActiveStorage, getInsecureStorage } from "./token";
 import { storageSettings } from "../sessionManager/index.js";
 import {
   StorageKeys,

--- a/lib/utils/activityTracking.ts
+++ b/lib/utils/activityTracking.ts
@@ -45,7 +45,7 @@ export const updateActivityTimestamp = (): void => {
         console.error("Failed to destroy secure session:", error);
       }
       const insecureStorage = getInsecureStorage();
-      if (insecureStorage) {
+      if (insecureStorage && insecureStorage !== sessionManager) {
         try {
           await insecureStorage.destroySession();
         } catch (error) {

--- a/lib/utils/activityTracking.ts
+++ b/lib/utils/activityTracking.ts
@@ -1,0 +1,106 @@
+import { storageSettings } from "../sessionManager/index.js";
+import { StorageKeys, type SessionManager } from "../sessionManager/types.js";
+
+/**
+ * Custom error class for activity expiration
+ */
+export class ActivityExpiredError extends Error {
+  constructor(message = "Session expired due to inactivity") {
+    super(message);
+    this.name = "ActivityExpiredError";
+  }
+}
+
+/**
+ * Creates a proxy around a SessionManager that automatically tracks user activity
+ * and enforces inactivity timeouts in middleware environments.
+ *
+ * @param sessionManager - The base SessionManager to wrap with activity tracking
+ * @returns A proxied SessionManager that automatically handles activity tracking
+ */
+export const createMiddlewareActivityProxy = <T extends string>(
+  sessionManager: SessionManager<T>,
+): SessionManager<T> => {
+  if (!storageSettings.activityTimeoutMinutes) {
+    return sessionManager;
+  }
+
+  const activityKey = `${storageSettings.keyPrefix}${StorageKeys.lastActivity}`;
+  const cleanupActivityData = async (): Promise<void> => {
+    try {
+      await sessionManager.removeSessionItem(activityKey as T);
+    } catch (cleanupError) {
+      console.warn(
+        "js-utils: Failed to cleanup activity data during expiry:",
+        cleanupError,
+      );
+    }
+  };
+
+  const checkActivityExpiry = async (): Promise<void> => {
+    const lastActivityValue = await sessionManager.getSessionItem(
+      activityKey as T,
+    );
+
+    if (lastActivityValue != null) {
+      try {
+        let lastActivity: number;
+
+        if (typeof lastActivityValue === "string") {
+          lastActivity = parseInt(lastActivityValue, 10);
+        } else if (typeof lastActivityValue === "number") {
+          lastActivity = lastActivityValue;
+        } else {
+          await cleanupActivityData();
+          throw new ActivityExpiredError();
+        }
+
+        if (!isNaN(lastActivity)) {
+          const timeoutMs = storageSettings.activityTimeoutMinutes! * 60 * 1000;
+          const timeSinceLastActivity = Date.now() - lastActivity;
+
+          if (timeSinceLastActivity > timeoutMs) {
+            await cleanupActivityData();
+            throw new ActivityExpiredError();
+          }
+        } else {
+          await cleanupActivityData();
+          throw new ActivityExpiredError();
+        }
+      } catch (error) {
+        if (error instanceof ActivityExpiredError) throw error;
+        await cleanupActivityData();
+        throw new ActivityExpiredError();
+      }
+    }
+  };
+
+  const updateActivityTimestamp = async (): Promise<void> => {
+    const timestamp = Date.now().toString();
+    await sessionManager.setSessionItem(activityKey as T, timestamp);
+  };
+
+  return new Proxy(sessionManager, {
+    get(target, prop) {
+      if (prop === "getSessionItem") {
+        return async <U = unknown>(itemKey: T | StorageKeys) => {
+          await checkActivityExpiry();
+          const result = await target.getSessionItem<U>(itemKey);
+          await updateActivityTimestamp();
+          return result;
+        };
+      }
+
+      if (prop === "setSessionItem") {
+        return async <U = unknown>(itemKey: T | StorageKeys, itemValue: U) => {
+          await checkActivityExpiry();
+          await target.setSessionItem(itemKey, itemValue);
+          await updateActivityTimestamp();
+        };
+      }
+
+      // Pass through other methods without tracking
+      return target[prop as keyof SessionManager<T>];
+    },
+  });
+};

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -18,5 +18,5 @@ export { generateProfileUrl } from "./generatePortalUrl";
 export { navigateToKinde } from "./navigateToKinde";
 export {
   updateActivityTimestamp,
-  ActivityExpiredError,
+  sessionManagerActivityProxy,
 } from "./activityTracking";

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -16,3 +16,7 @@ export { splitString } from "./splitString";
 export { generatePortalUrl } from "./generatePortalUrl";
 export { generateProfileUrl } from "./generatePortalUrl";
 export { navigateToKinde } from "./navigateToKinde";
+export {
+  createMiddlewareActivityProxy,
+  ActivityExpiredError,
+} from "./activityTracking";

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -17,6 +17,6 @@ export { generatePortalUrl } from "./generatePortalUrl";
 export { generateProfileUrl } from "./generatePortalUrl";
 export { navigateToKinde } from "./navigateToKinde";
 export {
-  createMiddlewareActivityProxy,
+  updateActivityTimestamp,
   ActivityExpiredError,
 } from "./activityTracking";

--- a/lib/utils/token/index.ts
+++ b/lib/utils/token/index.ts
@@ -38,7 +38,7 @@ const storage = {
  */
 export const setActiveStorage = (store: SessionManager) => {
   if (storageSettings.activityTimeoutMinutes) {
-    storage.secure = sessionManagerActivityProxy();
+    storage.secure = sessionManagerActivityProxy(store);
     return;
   }
   storage.secure = store;
@@ -73,7 +73,7 @@ export const clearActiveStorage = (): void => {
  */
 export const setInsecureStorage = (store: SessionManager) => {
   if (storageSettings.activityTimeoutMinutes) {
-    storage.insecure = sessionManagerActivityProxy("insecure");
+    storage.insecure = sessionManagerActivityProxy(store);
     return;
   }
 

--- a/lib/utils/token/index.ts
+++ b/lib/utils/token/index.ts
@@ -1,4 +1,5 @@
-import { SessionManager } from "../../sessionManager";
+import { SessionManager, storageSettings } from "../../sessionManager";
+import { sessionManagerActivityProxy } from "../activityTracking";
 
 export {
   has,
@@ -36,6 +37,10 @@ const storage = {
  * @param store Session manager instance
  */
 export const setActiveStorage = (store: SessionManager) => {
+  if (storageSettings.activityTimeoutMinutes) {
+    storage.secure = sessionManagerActivityProxy();
+    return;
+  }
   storage.secure = store;
 };
 
@@ -67,6 +72,11 @@ export const clearActiveStorage = (): void => {
  * @param store Session manager instance
  */
 export const setInsecureStorage = (store: SessionManager) => {
+  if (storageSettings.activityTimeoutMinutes) {
+    storage.insecure = sessionManagerActivityProxy("insecure");
+    return;
+  }
+
   storage.insecure = store;
 };
 


### PR DESCRIPTION
# Explain your changes

This PR adds automatic activity tracking with session expiry functionality to @kinde/js-utils.

Key additions:

- **sessionManagerActivityProxy** - Wraps any SessionManager with automatic activity tracking
- **updateActivityTimestamp** - Manages activity timers and session cleanup
- Automatic cleanup of sessions when activity timeout expires
- Support for pre-warning callbacks before session expiry

**Recent fixes:**
- Fixed circular dependency between sessionManagerActivityProxy and updateActivityTimestamp 
- Properly bind methods in proxy to maintain correct 'this' context
- Added test coverage to verify proxy method binding works correctly (including destructured methods)

The proxy automatically tracks user activity on session operations and enforces inactivity timeouts, destroying sessions when the configured timeout period expires.

# Checklist

- [x] I have read the ["Pull requests" section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._