### PR TITLE
fix: resolve activity tracker infinite timeout loops

### DIFF
--- a/lib/utils/activityTracking.ts
+++ b/lib/utils/activityTracking.ts
@@ -65,7 +65,7 @@ export const updateActivityTimestamp = (): void => {
     storageSettings.activityTimeoutMinutes! * 60 * 1000,
   );
 
-  if (storageSettings.activityTimeoutPreWarningMinutes) {
+  if (storageSettings.activityTimeoutPreWarningMinutes !== undefined) {
     activityPreWarnTimer = setTimeout(
       () => {
         try {


### PR DESCRIPTION
# Explain your changes

## Problem
When timeout occurred, `destroySession()` went through the activity proxy, which called `updateActivityTimestamp()`, creating new timers in an infinite loop.

## Testing
Added regression test `"should fire timeout callbacks only once per inactivity cycle"` that verifies correct behavior and prevents future regressions.

# Checklist

- [x] I have read the ["Pull requests" section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._