### PR TITLE
feat: add isTokenExpired method

### DIFF
--- a/lib/main.test.ts
+++ b/lib/main.test.ts
@@ -48,6 +48,7 @@ describe("index exports", () => {
       "sanitizeUrl",
       "exchangeAuthCode",
       "isAuthenticated",
+      "isTokenExpired",
       "refreshToken",
       "checkAuth",
       "isCustomDomain",

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -38,6 +38,7 @@ export {
   getUserOrganizations,
   getRoles,
   isAuthenticated,
+  isTokenExpired,
   refreshToken,
   setActiveStorage,
   getActiveStorage,

--- a/lib/utils/token/index.ts
+++ b/lib/utils/token/index.ts
@@ -25,6 +25,7 @@ export { getUserOrganizations } from "./getUserOrganizations";
 export { getRoles } from "./getRoles";
 export type { Role } from "./getRoles";
 export { isAuthenticated } from "./isAuthenticated";
+export { isTokenExpired } from "./isTokenExpired";
 export { refreshToken } from "./refreshToken";
 export { getEntitlements } from "./getEntitlements";
 const storage = {

--- a/lib/utils/token/isAuthenticated.test.ts
+++ b/lib/utils/token/isAuthenticated.test.ts
@@ -83,7 +83,7 @@ describe("isAuthenticated", () => {
 
   it("should return false and log error if an exception occurs", async () => {
     const mockError = new Error("Test error");
-    vi.spyOn(tokenUtils, "getDecodedToken").mockRejectedValue(mockError);
+    vi.spyOn(tokenUtils, "isTokenExpired").mockRejectedValue(mockError);
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     const result = await isAuthenticated();

--- a/lib/utils/token/isTokenExpired.test.ts
+++ b/lib/utils/token/isTokenExpired.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as tokenUtils from ".";
+import { isTokenExpired } from "./isTokenExpired";
+
+// Mock the entire token utils module
+vi.mock("..");
+
+describe("isTokenExpired", () => {
+  const mockCurrentTime = 1000000000;
+
+  beforeEach(() => {
+    // Mock Date.now() to return a fixed timestamp
+    vi.spyOn(Date, "now").mockImplementation(() => mockCurrentTime * 1000);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should return false if no token is found", async () => {
+    vi.spyOn(tokenUtils, "getDecodedToken").mockResolvedValue(null);
+
+    const result = await isTokenExpired();
+
+    expect(result).toBe(true);
+  });
+
+  it("should return true if token is valid and not expired", async () => {
+    vi.spyOn(tokenUtils, "getDecodedToken").mockResolvedValue({
+      exp: mockCurrentTime + 3600,
+    });
+
+    const result = await isTokenExpired();
+
+    expect(result).toBe(false);
+  });
+
+  it("should return true if token contains no expiry", async () => {
+    vi.spyOn(tokenUtils, "getDecodedToken").mockResolvedValue({
+      exp: undefined,
+    });
+
+    const result = await isTokenExpired();
+
+    expect(result).toBe(true);
+  });
+
+  it("should return false if token is not expired within threshold", async () => {
+    vi.spyOn(tokenUtils, "getDecodedToken").mockResolvedValue({
+      exp: mockCurrentTime + 3600, // expires in 1 hour
+    });
+
+    const result = await isTokenExpired({ threshold: 5 }); // 5 second threshold
+
+    expect(result).toBe(false); // not expired within 5 seconds
+  });
+
+  it("should return true if token expires within threshold", async () => {
+    vi.spyOn(tokenUtils, "getDecodedToken").mockResolvedValue({
+      exp: mockCurrentTime + 3, // expires in 3 seconds
+    });
+
+    const result = await isTokenExpired({ threshold: 5 }); // 5 second threshold
+
+    expect(result).toBe(true); // expired within 5 seconds
+  });
+});

--- a/lib/utils/token/isTokenExpired.ts
+++ b/lib/utils/token/isTokenExpired.ts
@@ -1,0 +1,31 @@
+import { JWTDecoded } from "@kinde/jwt-decoder";
+import { getDecodedToken } from ".";
+
+type IsTokenExpiredProps = {
+  /**
+   * Threshold in seconds to expire the token before the actual expiry
+   */
+  threshold?: number;
+};
+/**
+ * check if the user is authenticated with option to refresh the token
+ * @returns { Promise<boolean> }
+ */
+export const isTokenExpired = async (
+  props?: IsTokenExpiredProps,
+): Promise<boolean> => {
+  try {
+    const token = await getDecodedToken<JWTDecoded>("accessToken");
+    if (!token) return true;
+
+    if (!token.exp) {
+      console.error("Token does not have an expiry");
+      return true;
+    }
+
+    return token.exp < Math.floor(Date.now() / 1000) + (props?.threshold || 0);
+  } catch (error) {
+    console.error("Error checking authentication:", error);
+    return false;
+  }
+};


### PR DESCRIPTION
# Explain your changes

Added a `isTokenExpired` helper method, updated `isAuthenticated` to use this method

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
