### PR TITLE
feat: add windowless support to functions

### DIFF
--- a/lib/main.test.ts
+++ b/lib/main.test.ts
@@ -59,6 +59,8 @@ describe("index exports", () => {
       "navigateToKinde",
       "updateActivityTimestamp",
       "sessionManagerActivityProxy",
+      "isClient",
+      "isServer",
 
       // session manager
       "MemoryStorage",

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -22,6 +22,8 @@ export {
   navigateToKinde,
   updateActivityTimestamp,
   sessionManagerActivityProxy,
+  isClient,
+  isServer,
 } from "./utils";
 
 export {

--- a/lib/utils/exchangeAuthCode.ts
+++ b/lib/utils/exchangeAuthCode.ts
@@ -8,6 +8,7 @@ import {
 } from "../main";
 import { isCustomDomain } from ".";
 import { clearRefreshTimer, setRefreshTimer } from "./refreshTimer";
+import { isClient } from "./isClient";
 
 export const frameworkSettings: {
   framework: string;
@@ -211,7 +212,7 @@ export const exchangeAuthCode = async ({
     return url;
   };
 
-  if (typeof window !== "undefined") {
+  if (isClient()) {
     const url = cleanUrl(new URL(window.location.toString()));
     // Replace current state and clear forward history
     window.history.replaceState(window.history.state, "", url);

--- a/lib/utils/exchangeAuthCode.ts
+++ b/lib/utils/exchangeAuthCode.ts
@@ -210,10 +210,12 @@ export const exchangeAuthCode = async ({
     url.search = "";
     return url;
   };
-  const url = cleanUrl(new URL(window.location.toString()));
-  // Replace current state and clear forward history
-  window.history.replaceState(window.history.state, "", url);
 
+  if (typeof window !== "undefined") {
+    const url = cleanUrl(new URL(window.location.toString()));
+    // Replace current state and clear forward history
+    window.history.replaceState(window.history.state, "", url);
+  }
   if (!data.access_token || !data.id_token || !data.refresh_token) {
     return {
       success: false,

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -20,3 +20,5 @@ export {
   updateActivityTimestamp,
   sessionManagerActivityProxy,
 } from "./activityTracking";
+export { isClient } from "./isClient";
+export { isServer } from "./isServer";

--- a/lib/utils/isClient.test.ts
+++ b/lib/utils/isClient.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { isClient } from "./isClient";
+
+describe("isClient", () => {
+  let originalWindow: typeof globalThis.window;
+
+  beforeEach(() => {
+    // Save the original window object
+    originalWindow = globalThis.window;
+  });
+
+  afterEach(() => {
+    // Restore the original window object
+    globalThis.window = originalWindow;
+  });
+
+  it("should return true when window is defined (client environment)", () => {
+    // Ensure window is defined (default in vitest browser mode)
+    if (typeof globalThis.window === "undefined") {
+      // @ts-expect-error - Setting window for testing purposes
+      globalThis.window = {};
+    }
+
+    const result = isClient();
+    expect(result).toBe(true);
+  });
+
+  it("should return false when window is undefined (server environment)", () => {
+    // @ts-expect-error - Deleting window for testing purposes
+    delete globalThis.window;
+
+    const result = isClient();
+    expect(result).toBe(false);
+  });
+
+  it("should return true when window exists with properties", () => {
+    globalThis.window = {} as Window & typeof globalThis;
+
+    const result = isClient();
+    expect(result).toBe(true);
+  });
+
+  it("should return true even when window is an empty object", () => {
+    // @ts-expect-error - Setting window for testing purposes
+    globalThis.window = {};
+
+    const result = isClient();
+    expect(result).toBe(true);
+  });
+
+  it("should consistently return the same result when called multiple times", () => {
+    const firstCall = isClient();
+    const secondCall = isClient();
+    const thirdCall = isClient();
+
+    expect(firstCall).toBe(secondCall);
+    expect(secondCall).toBe(thirdCall);
+  });
+
+  it("should return false when window is explicitly set to undefined", () => {
+    // @ts-expect-error - Setting window to undefined for testing purposes
+    globalThis.window = undefined;
+
+    const result = isClient();
+    expect(result).toBe(false);
+  });
+});

--- a/lib/utils/isClient.ts
+++ b/lib/utils/isClient.ts
@@ -1,0 +1,23 @@
+/**
+ * Checks if the code is running in a client/browser environment.
+ * 
+ * This function determines whether the code is executing in a client-side
+ * environment by checking if the 'window' object is defined. It returns
+ * true for client/browser environments and false for server environments.
+ * 
+ * @returns True if running in browser/client, false if running on server
+ * 
+ * @example
+ * ```typescript
+ * // In browser
+ * isClient() 
+ * // Returns: true
+ * 
+ * // On Node.js server
+ * isClient()
+ * // Returns: false
+ * ```
+ */
+export const isClient = () => {
+    return typeof window !== "undefined";
+}

--- a/lib/utils/isClient.ts
+++ b/lib/utils/isClient.ts
@@ -1,23 +1,23 @@
 /**
  * Checks if the code is running in a client/browser environment.
- * 
+ *
  * This function determines whether the code is executing in a client-side
  * environment by checking if the 'window' object is defined. It returns
  * true for client/browser environments and false for server environments.
- * 
+ *
  * @returns True if running in browser/client, false if running on server
- * 
+ *
  * @example
  * ```typescript
  * // In browser
- * isClient() 
+ * isClient()
  * // Returns: true
- * 
+ *
  * // On Node.js server
  * isClient()
  * // Returns: false
  * ```
  */
 export const isClient = () => {
-    return typeof window !== "undefined";
-}
+  return typeof window !== "undefined";
+};

--- a/lib/utils/isServer.test.ts
+++ b/lib/utils/isServer.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { isServer } from "./isServer";
+
+describe("isServer", () => {
+  let originalWindow: typeof globalThis.window;
+
+  beforeEach(() => {
+    // Save the original window object
+    originalWindow = globalThis.window;
+  });
+
+  afterEach(() => {
+    // Restore the original window object
+    globalThis.window = originalWindow;
+  });
+
+  it("should return false when window is defined (client environment)", () => {
+    // Ensure window is defined (default in vitest browser mode)
+    if (typeof globalThis.window === "undefined") {
+      // @ts-expect-error - Setting window for testing purposes
+      globalThis.window = {};
+    }
+
+    const result = isServer();
+    expect(result).toBe(false);
+  });
+
+  it("should return true when window is undefined (server environment)", () => {
+    // @ts-expect-error - Deleting window for testing purposes
+    delete globalThis.window;
+
+    const result = isServer();
+    expect(result).toBe(true);
+  });
+
+  it("should return false when window exists with properties", () => {
+    globalThis.window = {} as Window & typeof globalThis;
+
+    const result = isServer();
+    expect(result).toBe(false);
+  });
+
+  it("should return false even when window is an empty object", () => {
+    // @ts-expect-error - Setting window for testing purposes
+    globalThis.window = {};
+
+    const result = isServer();
+    expect(result).toBe(false);
+  });
+
+  it("should consistently return the same result when called multiple times", () => {
+    const firstCall = isServer();
+    const secondCall = isServer();
+    const thirdCall = isServer();
+
+    expect(firstCall).toBe(secondCall);
+    expect(secondCall).toBe(thirdCall);
+  });
+
+  it("should return true when window is explicitly set to undefined", () => {
+    // @ts-expect-error - Setting window to undefined for testing purposes
+    globalThis.window = undefined;
+
+    const result = isServer();
+    expect(result).toBe(true);
+  });
+
+  it("should be the inverse of isClient", () => {
+    // Test with window defined
+    if (typeof globalThis.window === "undefined") {
+      // @ts-expect-error - Setting window for testing purposes
+      globalThis.window = {};
+    }
+
+    const clientResult = isServer();
+    expect(clientResult).toBe(false);
+
+    // Test with window undefined
+    // @ts-expect-error - Deleting window for testing purposes
+    delete globalThis.window;
+
+    const serverResult = isServer();
+    expect(serverResult).toBe(true);
+  });
+});

--- a/lib/utils/isServer.ts
+++ b/lib/utils/isServer.ts
@@ -2,20 +2,20 @@ import { isClient } from "./isClient";
 
 /**
  * Checks if the code is running in a server environment.
- * 
+ *
  * This function determines whether the code is executing in a server-side
  * environment by checking if the 'window' object is undefined. It returns
  * the opposite of isClient(), meaning it returns true for server environments
  * and false for client/browser environments.
- * 
+ *
  * @returns True if running on server, false if running in browser/client
- * 
+ *
  * @example
  * ```typescript
  * // On Node.js server
- * isServer() 
+ * isServer()
  * // Returns: true
- * 
+ *
  * // In browser
  * isServer()
  * // Returns: false

--- a/lib/utils/isServer.ts
+++ b/lib/utils/isServer.ts
@@ -1,0 +1,24 @@
+import { isClient } from "./isClient";
+
+/**
+ * Checks if the code is running in a server environment.
+ * 
+ * This function determines whether the code is executing in a server-side
+ * environment by checking if the 'window' object is undefined. It returns
+ * the opposite of isClient(), meaning it returns true for server environments
+ * and false for client/browser environments.
+ * 
+ * @returns True if running on server, false if running in browser/client
+ * 
+ * @example
+ * ```typescript
+ * // On Node.js server
+ * isServer() 
+ * // Returns: true
+ * 
+ * // In browser
+ * isServer()
+ * // Returns: false
+ * ```
+ */
+export const isServer = () => !isClient();

--- a/lib/utils/refreshTimer.ts
+++ b/lib/utils/refreshTimer.ts
@@ -70,8 +70,10 @@ export function setRefreshTimer(timer: number, callback: () => void) {
  * ```
  */
 export function clearRefreshTimer() {
-  if (refreshTimer !== undefined) {
-    window.clearTimeout(refreshTimer);
-    refreshTimer = undefined;
+  if (isClient()) {
+    if (refreshTimer !== undefined) {
+      window.clearTimeout(refreshTimer);
+      refreshTimer = undefined;
+    }
   }
 }

--- a/lib/utils/refreshTimer.ts
+++ b/lib/utils/refreshTimer.ts
@@ -1,3 +1,5 @@
+import { isClient } from "./isClient";
+
 /**
  * Global timer reference for managing refresh timers.
  * Used to store the timeout ID for the current refresh timer.
@@ -37,7 +39,7 @@ let refreshTimer: number | undefined;
  */
 export function setRefreshTimer(timer: number, callback: () => void) {
   clearRefreshTimer();
-  if (typeof window === "undefined") {
+  if (!isClient()) {
     throw new Error("setRefreshTimer requires a browser environment");
   }
   if (timer <= 0) {

--- a/lib/utils/token/refreshToken.ts
+++ b/lib/utils/token/refreshToken.ts
@@ -106,9 +106,11 @@ export const refreshToken = async ({
           error: "No active storage found",
         });
       }
-      setRefreshTimer(data.expires_in, async () => {
-        refreshToken({ domain, clientId, refreshType, onRefresh });
-      });
+      if (typeof window !== "undefined") {
+        setRefreshTimer(data.expires_in, async () => {
+          refreshToken({ domain, clientId, refreshType, onRefresh });
+        });
+      }
 
       if (storage) {
         await secureStore.setSessionItem(

--- a/lib/utils/token/refreshToken.ts
+++ b/lib/utils/token/refreshToken.ts
@@ -8,6 +8,7 @@ import { isCustomDomain, sanitizeUrl } from "..";
 import { clearRefreshTimer, setRefreshTimer } from "../refreshTimer";
 import type { RefreshTokenResult } from "../../main";
 import { RefreshType } from "../../main";
+import { isClient } from "../isClient";
 
 /**
  * refreshes the token
@@ -106,7 +107,7 @@ export const refreshToken = async ({
           error: "No active storage found",
         });
       }
-      if (typeof window !== "undefined") {
+      if (isClient()) {
         setRefreshTimer(data.expires_in, async () => {
           refreshToken({ domain, clientId, refreshType, onRefresh });
         });


### PR DESCRIPTION
This removes the requirement for `window` to exist.  Allows for server side methods to use functions like `refreshToken`

Adds exports for `isClient` and `isServer` helpers

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
