### PR TITLE
feat: add onRefreshHandler to custom handle token refreshes

### DIFF
--- a/lib/sessionManager/types.ts
+++ b/lib/sessionManager/types.ts
@@ -1,3 +1,5 @@
+import { RefreshTokenResult, RefreshType } from "../types";
+
 /**
  * This interfaces provides the contract that an session management utility must
  * satisfiy in order to work with this SDK, please vist the example provided in the
@@ -31,6 +33,10 @@ export type StorageSettingsType = {
   onActivityTimeout?: (
     timeoutType: TimeoutActivityType,
   ) => void | Promise<void>;
+  /**
+   *
+   */
+  onRefreshHandler?: (refreshType: RefreshType) => Promise<RefreshTokenResult>;
 };
 
 export abstract class SessionBase<V extends string = StorageKeys>

--- a/lib/utils/token/refreshToken.test.ts
+++ b/lib/utils/token/refreshToken.test.ts
@@ -6,6 +6,8 @@ import {
 } from "../../sessionManager";
 import * as tokenUtils from ".";
 import * as refreshTimer from "../refreshTimer";
+import { createMockAccessToken } from "./testUtils";
+import * as isClient from "../isClient";
 
 describe("refreshToken", () => {
   const mockDomain = "https://example.com";
@@ -293,6 +295,7 @@ describe("refreshToken", () => {
       refresh_token: "new-refresh-token",
       expires_in: 1000,
     };
+    vi.spyOn(isClient, "isClient").mockResolvedValue(true);
 
     const insecureStorage = new MemoryStorage();
     tokenUtils.setInsecureStorage(insecureStorage);
@@ -325,6 +328,245 @@ describe("refreshToken", () => {
       idToken: "new-id-token",
       refreshToken: "new-refresh-token",
       success: true,
+    });
+  });
+
+  describe("onRefreshHandler functionality", () => {
+    beforeEach(() => {
+      // Reset storageSettings to ensure clean state
+      storageSettings.onRefreshHandler = undefined;
+    });
+
+    afterEach(() => {
+      // Clean up storageSettings after each test
+      storageSettings.onRefreshHandler = undefined;
+    });
+
+    it("should use onRefreshHandler instead of fetch when set", async () => {
+      const mockOnRefreshHandler = vi.fn().mockResolvedValue({
+        success: true,
+        accessToken: createMockAccessToken({ exp: 1000 }),
+        idToken: "handler-id-token",
+        refreshToken: "handler-refresh-token",
+      });
+
+      storageSettings.onRefreshHandler = mockOnRefreshHandler;
+
+      const result = await tokenUtils.refreshToken({
+        domain: mockDomain,
+        clientId: mockClientId,
+        refreshType: 1, // RefreshType.cookie - this skips the refresh token check
+      });
+
+      // Verify onRefreshHandler was called with correct refreshType
+      expect(mockOnRefreshHandler).toHaveBeenCalledWith(1); // RefreshType.cookie = 1
+
+      // Verify fetch was not called
+      expect(global.fetch).not.toHaveBeenCalled();
+
+      // Verify the result from onRefreshHandler is returned
+      expect(result).toStrictEqual({
+        success: true,
+        accessToken:
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOltdLCJhenAiOiJiOWRhMThjNDQxYjQ0ZDgxYmFiM2U4MjMyZGUyZTE4ZCIsImJpbGxpbmciOnsiaGFzX3BheW1lbnRfZGV0YWlscyI6ZmFsc2V9LCJleHAiOjEwMDAsImlhdCI6MTE2ODMzNTcyMDAwMCwiaXNzIjoiaHR0cHM6Ly9raW5kZS5jb20iLCJqdGkiOiIyN2RhYTEyNS0yZmIyLTRlMTQtOTI3MC03NDJjZDU2ZTc2NGIiLCJvcmdfY29kZSI6Im9yZ18xMjM0NTY3ODkiLCJzY3AiOlsib3BlbmlkIiwicHJvZmlsZSIsImVtYWlsIiwib2ZmbGluZSJdLCJzdWIiOiJrcF9jZmNiMWFlNWI5MjU0YWQ5OTUyMTIxNDAxNGM1NGY0MyJ9.gtSHqb04MR1ul0kiS_mVDLY_02HbwjEPNI9koRCoDNw",
+        idToken: "handler-id-token",
+        refreshToken: "handler-refresh-token",
+      });
+
+      // Verify tokens are stored in session
+      expect(memoryStorage.setSessionItem).toHaveBeenCalledWith(
+        StorageKeys.accessToken,
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOltdLCJhenAiOiJiOWRhMThjNDQxYjQ0ZDgxYmFiM2U4MjMyZGUyZTE4ZCIsImJpbGxpbmciOnsiaGFzX3BheW1lbnRfZGV0YWlscyI6ZmFsc2V9LCJleHAiOjEwMDAsImlhdCI6MTE2ODMzNTcyMDAwMCwiaXNzIjoiaHR0cHM6Ly9raW5kZS5jb20iLCJqdGkiOiIyN2RhYTEyNS0yZmIyLTRlMTQtOTI3MC03NDJjZDU2ZTc2NGIiLCJvcmdfY29kZSI6Im9yZ18xMjM0NTY3ODkiLCJzY3AiOlsib3BlbmlkIiwicHJvZmlsZSIsImVtYWlsIiwib2ZmbGluZSJdLCJzdWIiOiJrcF9jZmNiMWFlNWI5MjU0YWQ5OTUyMTIxNDAxNGM1NGY0MyJ9.gtSHqb04MR1ul0kiS_mVDLY_02HbwjEPNI9koRCoDNw",
+      );
+      expect(memoryStorage.setSessionItem).toHaveBeenCalledWith(
+        StorageKeys.idToken,
+        "handler-id-token",
+      );
+      expect(memoryStorage.setSessionItem).toHaveBeenCalledWith(
+        StorageKeys.refreshToken,
+        "handler-refresh-token",
+      );
+    });
+
+    it("should handle onRefreshHandler error result", async () => {
+      const mockOnRefreshHandler = vi.fn().mockResolvedValue({
+        success: false,
+        error: "Handler refresh failed",
+      });
+
+      storageSettings.onRefreshHandler = mockOnRefreshHandler;
+
+      const result = await tokenUtils.refreshToken({
+        domain: mockDomain,
+        clientId: mockClientId,
+        refreshType: 1, // RefreshType.cookie - this skips the refresh token check
+      });
+
+      // Verify onRefreshHandler was called
+      expect(mockOnRefreshHandler).toHaveBeenCalledWith(1);
+
+      // Verify fetch was not called
+      expect(global.fetch).not.toHaveBeenCalled();
+
+      // Verify error result is returned
+      expect(result).toStrictEqual({
+        success: false,
+        error: "No access token received",
+      });
+
+      // Verify no tokens are stored on error
+      expect(memoryStorage.setSessionItem).not.toHaveBeenCalledWith(
+        StorageKeys.accessToken,
+        expect.any(String),
+      );
+    });
+
+    it("should call onRefresh callback when onRefreshHandler is used", async () => {
+      const mockOnRefreshHandler = vi.fn().mockResolvedValue({
+        success: true,
+        accessToken: "handler-access-token",
+        idToken: "handler-id-token",
+        refreshToken: "handler-refresh-token",
+      });
+
+      const mockOnRefreshCallback = vi.fn();
+
+      storageSettings.onRefreshHandler = mockOnRefreshHandler;
+
+      const result = await tokenUtils.refreshToken({
+        domain: mockDomain,
+        clientId: mockClientId,
+        refreshType: 1, // RefreshType.cookie - this skips the refresh token check
+        onRefresh: mockOnRefreshCallback,
+      });
+
+      // Verify onRefresh callback was called with the result
+      expect(mockOnRefreshCallback).toHaveBeenCalledWith({
+        success: true,
+        accessToken: "handler-access-token",
+        idToken: "handler-id-token",
+        refreshToken: "handler-refresh-token",
+      });
+
+      // Verify the result is still returned correctly
+      expect(result).toStrictEqual({
+        success: true,
+        accessToken: "handler-access-token",
+        idToken: "handler-id-token",
+        refreshToken: "handler-refresh-token",
+      });
+    });
+
+    it("should use onRefreshHandler with cookie refresh type", async () => {
+      const mockOnRefreshHandler = vi.fn().mockResolvedValue({
+        success: true,
+        accessToken: "cookie-access-token",
+        idToken: "cookie-id-token",
+        refreshToken: "cookie-refresh-token",
+      });
+
+      storageSettings.onRefreshHandler = mockOnRefreshHandler;
+
+      const result = await tokenUtils.refreshToken({
+        domain: mockDomain,
+        clientId: mockClientId,
+        refreshType: 1, // RefreshType.cookie
+      });
+
+      // Verify onRefreshHandler was called with cookie refresh type
+      expect(mockOnRefreshHandler).toHaveBeenCalledWith(1); // RefreshType.cookie = 1
+
+      // Verify fetch was not called
+      expect(global.fetch).not.toHaveBeenCalled();
+
+      // Verify the result from onRefreshHandler is returned
+      expect(result).toStrictEqual({
+        success: true,
+        accessToken: "cookie-access-token",
+        idToken: "cookie-id-token",
+        refreshToken: "cookie-refresh-token",
+      });
+    });
+
+    it("should handle onRefreshHandler throwing an error", async () => {
+      const mockOnRefreshHandler = vi
+        .fn()
+        .mockRejectedValue(new Error("Handler error"));
+
+      storageSettings.onRefreshHandler = mockOnRefreshHandler;
+
+      const result = await tokenUtils.refreshToken({
+        domain: mockDomain,
+        clientId: mockClientId,
+        refreshType: 1, // RefreshType.cookie - this skips the refresh token check
+      });
+
+      // Verify onRefreshHandler was called
+      expect(mockOnRefreshHandler).toHaveBeenCalledWith(1);
+
+      // Verify fetch was not called
+      expect(global.fetch).not.toHaveBeenCalled();
+
+      // Verify error is caught and returned
+      expect(result).toStrictEqual({
+        success: false,
+        error: "No access token received: Error: Handler error",
+      });
+    });
+
+    it("should start refresh timer when onRefreshHandler returns successful result", async () => {
+      vi.useFakeTimers();
+
+      const mockOnRefreshHandler = vi.fn().mockResolvedValue({
+        success: true,
+        accessToken: createMockAccessToken({ exp: 1000 }),
+        idToken: "handler-id-token",
+        refreshToken: "handler-refresh-token",
+      });
+
+      // Mock getClaim to return an exp value that's in the future
+      const futureExp = Math.floor(Date.now() / 1000) + 1000; // 1000 seconds in the future
+      vi.spyOn(tokenUtils, "getClaim").mockResolvedValue({
+        name: "exp",
+        value: futureExp,
+      });
+
+      storageSettings.onRefreshHandler = mockOnRefreshHandler;
+
+      const result = await tokenUtils.refreshToken({
+        domain: mockDomain,
+        clientId: mockClientId,
+        refreshType: 1, // RefreshType.cookie - this skips the refresh token check
+      });
+
+      // Verify onRefreshHandler was called
+      expect(mockOnRefreshHandler).toHaveBeenCalledWith(1);
+
+      // Verify fetch was not called
+      expect(global.fetch).not.toHaveBeenCalled();
+
+      // Verify refresh timer was set
+      expect(refreshTimer.setRefreshTimer).toHaveBeenCalledWith(
+        1000,
+        expect.any(Function),
+      );
+
+      // Verify the result is returned correctly
+      expect(result).toStrictEqual({
+        success: true,
+        accessToken:
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOltdLCJhenAiOiJiOWRhMThjNDQxYjQ0ZDgxYmFiM2U4MjMyZGUyZTE4ZCIsImJpbGxpbmciOnsiaGFzX3BheW1lbnRfZGV0YWlscyI6ZmFsc2V9LCJleHAiOjEwMDAsImlhdCI6MTE2ODMzNTcyMDAwMCwiaXNzIjoiaHR0cHM6Ly9raW5kZS5jb20iLCJqdGkiOiIyN2RhYTEyNS0yZmIyLTRlMTQtOTI3MC03NDJjZDU2ZTc2NGIiLCJvcmdfY29kZSI6Im9yZ18xMjM0NTY3ODkiLCJzY3AiOlsib3BlbmlkIiwicHJvZmlsZSIsImVtYWlsIiwib2ZmbGluZSJdLCJzdWIiOiJrcF9jZmNiMWFlNWI5MjU0YWQ5OTUyMTIxNDAxNGM1NGY0MyJ9.gtSHqb04MR1ul0kiS_mVDLY_02HbwjEPNI9koRCoDNw",
+        idToken: "handler-id-token",
+        refreshToken: "handler-refresh-token",
+      });
+
+      // Test that the timer callback works
+      vi.runAllTimers();
+      expect(tokenUtils.refreshToken).toHaveBeenCalledWith({
+        domain: mockDomain,
+        clientId: mockClientId,
+        refreshType: 1,
+      });
     });
   });
 });


### PR DESCRIPTION
# Explain your changes

To better support various libraries namely backend libraries, allow the consumer to override and supply a custom implementation on how the tokens are refreshed.

```
storageSettings.onRefreshHandler: () -> {
  // Refresh code goes here.
}
```

This will update relevant storages and start refresh timers as required.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
