### PR TITLE
fix: empty storage authCheck + tests

### DIFF
--- a/lib/utils/checkAuth.test.ts
+++ b/lib/utils/checkAuth.test.ts
@@ -1,15 +1,28 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as CheckAuth from "./checkAuth";
 import * as RefreshToken from "./token/refreshToken";
 import * as GetCookie from "./getCookie";
 import { RefreshType } from "../types";
+import { MemoryStorage, StorageKeys } from "../sessionManager";
+import { clearActiveStorage, setActiveStorage } from "../main";
+import { createMockAccessToken } from "./token/testUtils";
+import * as hasTokenExpired from "./token/isTokenExpired";
 
 describe("checkAuth", () => {
   const domain = "auth.test.com";
   const clientId = "client-id";
+  const storage = new MemoryStorage();
 
   beforeEach(() => {
     vi.clearAllMocks();
+
+    setActiveStorage(storage);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    storage.destroySession();
+    clearActiveStorage();
   });
 
   it("should use cookie refresh type when using not custom domain and no _kbrte cookie", async () => {
@@ -78,5 +91,80 @@ describe("checkAuth", () => {
       success: false,
       error: "Client ID is required for authentication check",
     });
+  });
+
+  // add a test for when storage is available and the token is expired
+  it("should use storage when available and token is invalid", async () => {
+    vi.spyOn(RefreshToken, "refreshToken").mockResolvedValue({
+      success: true,
+    });
+    vi.spyOn(GetCookie, "getCookie").mockReturnValue(null);
+    await storage.setSessionItem(StorageKeys.accessToken, "expired-token");
+
+    await CheckAuth.checkAuth({ domain, clientId });
+
+    expect(RefreshToken.refreshToken).toHaveBeenCalled();
+  });
+
+  // add a test for when storage is available and the token is expired
+  it("return from storage when available and token is valid", async () => {
+    vi.spyOn(RefreshToken, "refreshToken").mockResolvedValue({
+      success: true,
+    });
+    vi.spyOn(hasTokenExpired, "isTokenExpired").mockResolvedValue(false);
+    vi.spyOn(GetCookie, "getCookie").mockReturnValue(null);
+    const date = new Date();
+    await storage.setSessionItem(
+      StorageKeys.accessToken,
+      createMockAccessToken({ exp: date.getTime() }),
+    );
+    await storage.setSessionItem(
+      StorageKeys.idToken,
+      createMockAccessToken({ exp: date.getTime() }),
+    );
+    await storage.setSessionItem(
+      StorageKeys.refreshToken,
+      createMockAccessToken({ exp: date.getTime() }),
+    );
+
+    await CheckAuth.checkAuth({ domain, clientId });
+
+    expect(RefreshToken.refreshToken).not.toHaveBeenCalled();
+  });
+
+  it("should use storage when available and token is expired", async () => {
+    vi.spyOn(RefreshToken, "refreshToken").mockResolvedValue({
+      success: true,
+    });
+    vi.spyOn(hasTokenExpired, "isTokenExpired").mockResolvedValue(true);
+    vi.spyOn(GetCookie, "getCookie").mockReturnValue(null);
+    const date = new Date();
+    await storage.setSessionItem(
+      StorageKeys.accessToken,
+      createMockAccessToken({ exp: date.getTime() }),
+    );
+    await storage.setSessionItem(
+      StorageKeys.idToken,
+      createMockAccessToken({ exp: date.getTime() }),
+    );
+    await storage.setSessionItem(
+      StorageKeys.refreshToken,
+      createMockAccessToken({ exp: date.getTime() }),
+    );
+
+    await CheckAuth.checkAuth({ domain, clientId });
+
+    expect(RefreshToken.refreshToken).toHaveBeenCalled();
+  });
+
+  it("should only check if expired if storage is available", async () => {
+    vi.spyOn(RefreshToken, "refreshToken").mockResolvedValue({
+      success: true,
+    });
+    vi.spyOn(GetCookie, "getCookie").mockReturnValue(null);
+    vi.spyOn(hasTokenExpired, "isTokenExpired");
+    await CheckAuth.checkAuth({ domain, clientId });
+
+    expect(hasTokenExpired.isTokenExpired).not.toHaveBeenCalled();
   });
 });

--- a/lib/utils/checkAuth.ts
+++ b/lib/utils/checkAuth.ts
@@ -45,15 +45,15 @@ export const checkAuth = async ({
       StorageKeys.refreshToken,
     );
 
-    if (await isTokenExpired({ threshold: 10 })) {
-      return await refreshToken({
-        domain,
-        clientId,
-        refreshType: RefreshType.refreshToken,
-      });
-    }
-
     if (accessToken && idToken && storedRefreshToken) {
+      if (await isTokenExpired({ threshold: 10 })) {
+        return await refreshToken({
+          domain,
+          clientId,
+          refreshType: RefreshType.refreshToken,
+        });
+      }
+
       return {
         success: true,
         accessToken: accessToken as string,


### PR DESCRIPTION
# Explain your changes

Fix issue where is an empty active storage exists when checking auth, this will cause refresh to fail.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
