### PR TITLE
feat: add store listener/subscription mechanism

### DIFF
--- a/lib/sessionManager/stores/chromeStore.ts
+++ b/lib/sessionManager/stores/chromeStore.ts
@@ -29,7 +29,7 @@ export class ChromeStore<V extends string = StorageKeys>
   async destroySession(): Promise<void> {
     await chrome.storage.local.clear();
 
-    await this.notifyListeners();
+    this.notifyListeners();
   }
 
   /**
@@ -59,7 +59,7 @@ export class ChromeStore<V extends string = StorageKeys>
       [`${storageSettings.keyPrefix}${itemKey}0`]: itemValue,
     });
 
-    await this.notifyListeners();
+    this.notifyListeners();
   }
 
   /**
@@ -103,6 +103,6 @@ export class ChromeStore<V extends string = StorageKeys>
       index++;
     }
 
-    await this.notifyListeners();
+    this.notifyListeners();
   }
 }

--- a/lib/sessionManager/stores/chromeStore.ts
+++ b/lib/sessionManager/stores/chromeStore.ts
@@ -46,12 +46,13 @@ export class ChromeStore<V extends string = StorageKeys>
     await this.removeSessionItem(itemKey);
 
     if (typeof itemValue === "string") {
-      splitString(itemValue, storageSettings.maxLength).forEach(
-        async (splitValue, index) => {
-          await chrome.storage.local.set({
+      const chunks = splitString(itemValue, storageSettings.maxLength);
+      await Promise.all(
+        chunks.map((splitValue, index) =>
+          chrome.storage.local.set({
             [`${storageSettings.keyPrefix}${itemKey}${index}`]: splitValue,
-          });
-        },
+          }),
+        ),
       );
       this.notifyListeners();
       return;

--- a/lib/sessionManager/stores/chromeStore.ts
+++ b/lib/sessionManager/stores/chromeStore.ts
@@ -53,6 +53,7 @@ export class ChromeStore<V extends string = StorageKeys>
           });
         },
       );
+      this.notifyListeners();
       return;
     }
     await chrome.storage.local.set({

--- a/lib/sessionManager/stores/chromeStore.ts
+++ b/lib/sessionManager/stores/chromeStore.ts
@@ -28,6 +28,8 @@ export class ChromeStore<V extends string = StorageKeys>
    */
   async destroySession(): Promise<void> {
     await chrome.storage.local.clear();
+
+    await this.notifyListeners();
   }
 
   /**
@@ -56,6 +58,8 @@ export class ChromeStore<V extends string = StorageKeys>
     await chrome.storage.local.set({
       [`${storageSettings.keyPrefix}${itemKey}0`]: itemValue,
     });
+
+    await this.notifyListeners();
   }
 
   /**
@@ -98,5 +102,7 @@ export class ChromeStore<V extends string = StorageKeys>
       );
       index++;
     }
+
+    await this.notifyListeners();
   }
 }

--- a/lib/sessionManager/stores/expoSecureStore.ts
+++ b/lib/sessionManager/stores/expoSecureStore.ts
@@ -60,13 +60,17 @@ export class ExpoSecureStore<
     await this.removeSessionItem(itemKey);
 
     if (typeof itemValue === "string") {
-      splitString(itemValue, Math.min(storageSettings.maxLength, 2048)).forEach(
-        async (splitValue, index) => {
-          await expoSecureStore!.setItemAsync(
+      const chunks = splitString(
+        itemValue,
+        Math.min(storageSettings.maxLength, 2048),
+      );
+      await Promise.all(
+        chunks.map((splitValue, index) =>
+          expoSecureStore!.setItemAsync(
             `${storageSettings.keyPrefix}${itemKey}${index}`,
             splitValue,
-          );
-        },
+          ),
+        ),
       );
       this.notifyListeners();
       return;

--- a/lib/sessionManager/stores/expoSecureStore.ts
+++ b/lib/sessionManager/stores/expoSecureStore.ts
@@ -44,7 +44,7 @@ export class ExpoSecureStore<
       await this.removeSessionItem(key);
     });
 
-    await this.notifyListeners();
+    this.notifyListeners();
   }
 
   /**
@@ -75,7 +75,7 @@ export class ExpoSecureStore<
       throw new Error("Item value must be a string");
     }
 
-    await this.notifyListeners();
+    this.notifyListeners();
   }
 
   /**
@@ -130,6 +130,6 @@ export class ExpoSecureStore<
       );
     }
 
-    await this.notifyListeners();
+    this.notifyListeners();
   }
 }

--- a/lib/sessionManager/stores/expoSecureStore.ts
+++ b/lib/sessionManager/stores/expoSecureStore.ts
@@ -40,9 +40,7 @@ export class ExpoSecureStore<
    */
   async destroySession(): Promise<void> {
     const keys = Object.values(StorageKeys);
-    keys.forEach(async (key) => {
-      await this.removeSessionItem(key);
-    });
+    await Promise.all(keys.map((key) => this.removeSessionItem(key)));
 
     this.notifyListeners();
   }

--- a/lib/sessionManager/stores/expoSecureStore.ts
+++ b/lib/sessionManager/stores/expoSecureStore.ts
@@ -43,6 +43,8 @@ export class ExpoSecureStore<
     keys.forEach(async (key) => {
       await this.removeSessionItem(key);
     });
+
+    await this.notifyListeners();
   }
 
   /**
@@ -72,6 +74,8 @@ export class ExpoSecureStore<
     } else {
       throw new Error("Item value must be a string");
     }
+
+    await this.notifyListeners();
   }
 
   /**
@@ -125,5 +129,7 @@ export class ExpoSecureStore<
         `${storageSettings.keyPrefix}${String(itemKey)}${index}`,
       );
     }
+
+    await this.notifyListeners();
   }
 }

--- a/lib/sessionManager/stores/expoSecureStore.ts
+++ b/lib/sessionManager/stores/expoSecureStore.ts
@@ -70,12 +70,11 @@ export class ExpoSecureStore<
           );
         },
       );
+      this.notifyListeners();
       return;
     } else {
       throw new Error("Item value must be a string");
     }
-
-    this.notifyListeners();
   }
 
   /**

--- a/lib/sessionManager/stores/localStorage.test.ts
+++ b/lib/sessionManager/stores/localStorage.test.ts
@@ -409,7 +409,6 @@ describe("LocalStorage subscription/listening mechanism", () => {
     let listenerCallCount = 0;
 
     const listener = () => {
-      console.log("listener called");
       listenerCallCount++;
     };
 

--- a/lib/sessionManager/stores/localStorage.test.ts
+++ b/lib/sessionManager/stores/localStorage.test.ts
@@ -160,3 +160,296 @@ describe("LocalStorage keys: storageKeys", () => {
     expect(await sessionManager.getSessionItem(ExtraKeys.testKey)).toBeNull();
   });
 });
+
+describe("LocalStorage subscription/listening mechanism", () => {
+  let sessionManager: LocalStorage;
+
+  beforeEach(() => {
+    sessionManager = new LocalStorage();
+    localStorageMock.clear();
+  });
+
+  it("should call listener when item is set", async () => {
+    let listenerCalled = false;
+    const listener = () => {
+      listenerCalled = true;
+    };
+
+    sessionManager.subscribe(listener);
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "testValue");
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    expect(listenerCalled).toBe(true);
+  });
+
+  it("should call listener when item is removed", async () => {
+    let listenerCalled = false;
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "testValue");
+
+    const listener = () => {
+      listenerCalled = true;
+    };
+
+    sessionManager.subscribe(listener);
+    await sessionManager.removeSessionItem(StorageKeys.accessToken);
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    expect(listenerCalled).toBe(true);
+  });
+
+  it("should call listener when session is destroyed", async () => {
+    let listenerCalled = false;
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "testValue");
+
+    const listener = () => {
+      listenerCalled = true;
+    };
+
+    sessionManager.subscribe(listener);
+    await sessionManager.destroySession();
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    expect(listenerCalled).toBe(true);
+  });
+
+  it("should support multiple listeners", async () => {
+    let listener1Called = false;
+    let listener2Called = false;
+    let listener3Called = false;
+
+    const listener1 = () => {
+      listener1Called = true;
+    };
+    const listener2 = () => {
+      listener2Called = true;
+    };
+    const listener3 = () => {
+      listener3Called = true;
+    };
+
+    sessionManager.subscribe(listener1);
+    sessionManager.subscribe(listener2);
+    sessionManager.subscribe(listener3);
+
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "testValue");
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    expect(listener1Called).toBe(true);
+    expect(listener2Called).toBe(true);
+    expect(listener3Called).toBe(true);
+  });
+
+  it("should support asynchronous listeners", async () => {
+    let asyncListenerCalled = false;
+    let asyncListenerValue = "";
+
+    const asyncListener = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      asyncListenerCalled = true;
+      asyncListenerValue = (await sessionManager.getSessionItem(
+        StorageKeys.accessToken,
+      )) as string;
+    };
+
+    sessionManager.subscribe(asyncListener);
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "asyncTest");
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    // Wait a bit more for async listener to complete
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(asyncListenerCalled).toBe(true);
+    expect(asyncListenerValue).toBe("asyncTest");
+  });
+
+  it("should support mix of synchronous and asynchronous listeners", async () => {
+    let syncCalled = false;
+    let asyncCalled = false;
+
+    const syncListener = () => {
+      syncCalled = true;
+    };
+
+    const asyncListener = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      asyncCalled = true;
+    };
+
+    sessionManager.subscribe(syncListener);
+    sessionManager.subscribe(asyncListener);
+
+    await sessionManager.setSessionItem(StorageKeys.idToken, "mixedTest");
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    expect(syncCalled).toBe(true);
+
+    // Wait for async listener
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(asyncCalled).toBe(true);
+  });
+
+  it("should unsubscribe listener when unsubscribe function is called", async () => {
+    let listenerCalled = false;
+
+    const listener = () => {
+      listenerCalled = true;
+    };
+
+    const unsubscribe = sessionManager.subscribe(listener);
+
+    // First change should trigger listener
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "test1");
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+    expect(listenerCalled).toBe(true);
+
+    // Reset and unsubscribe
+    listenerCalled = false;
+    unsubscribe();
+
+    // Second change should not trigger listener
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "test2");
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+    expect(listenerCalled).toBe(false);
+  });
+
+  it("should batch multiple synchronous calls into single notification", async () => {
+    let callCount = 0;
+
+    const listener = () => {
+      callCount++;
+    };
+
+    sessionManager.subscribe(listener);
+
+    // Perform multiple operations synchronously
+    const promise1 = sessionManager.setSessionItem(
+      StorageKeys.accessToken,
+      "value1",
+    );
+    const promise2 = sessionManager.setSessionItem(
+      StorageKeys.idToken,
+      "value2",
+    );
+    const promise3 = sessionManager.setSessionItem(
+      StorageKeys.refreshToken,
+      "value3",
+    );
+
+    await Promise.all([promise1, promise2, promise3]);
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    // Even though we made 3 changes, listener should be called more than once
+    // but less than 3 times due to batching
+    expect(callCount).toBeGreaterThan(0);
+    expect(callCount).toBeLessThanOrEqual(3);
+  });
+
+  it("should allow same listener to be subscribed multiple times", async () => {
+    let callCount = 0;
+
+    const listener = () => {
+      callCount++;
+    };
+
+    // Subscribe same listener twice
+    sessionManager.subscribe(listener);
+    sessionManager.subscribe(listener);
+
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "testValue");
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    // Since Set is used, listener should only be called once
+    expect(callCount).toBe(1);
+  });
+
+  it("should support unsubscribing one instance while keeping others", async () => {
+    let listener1Called = false;
+    let listener2Called = false;
+
+    const listener1 = () => {
+      listener1Called = true;
+    };
+
+    const listener2 = () => {
+      listener2Called = true;
+    };
+
+    const unsubscribe1 = sessionManager.subscribe(listener1);
+    sessionManager.subscribe(listener2);
+
+    // Unsubscribe first listener
+    unsubscribe1();
+
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "testValue");
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    expect(listener1Called).toBe(false);
+    expect(listener2Called).toBe(true);
+  });
+
+  it("should notify listeners on setItems batch operation", async () => {
+    let listenerCallCount = 0;
+
+    const listener = () => {
+      console.log("listener called");
+      listenerCallCount++;
+    };
+
+    sessionManager.subscribe(listener);
+
+    await sessionManager.setItems({
+      [StorageKeys.accessToken]: "token1",
+      [StorageKeys.idToken]: "token2",
+      [StorageKeys.refreshToken]: "token3",
+    });
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    // Should be called at least once (batching may reduce call count)
+    expect(listenerCallCount).toBeGreaterThan(0);
+  });
+
+  it("should not batch multiple calls when operations are separated by microtask boundaries", async () => {
+    const callLog: string[] = [];
+
+    const listener = () => {
+      callLog.push("listener called");
+    };
+
+    sessionManager.subscribe(listener);
+
+    // Set item
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "test1");
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    // Remove item
+    await sessionManager.removeSessionItem(StorageKeys.accessToken);
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    // Set another item
+    await sessionManager.setSessionItem(StorageKeys.idToken, "test2");
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    // Each operation should trigger the listener when awaited between operations
+    expect(callLog.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/lib/sessionManager/stores/localStorage.ts
+++ b/lib/sessionManager/stores/localStorage.ts
@@ -54,6 +54,7 @@ export class LocalStorage<V extends string = StorageKeys>
           );
         },
       );
+      this.notifyListeners();
       return;
     }
     localStorage.setItem(

--- a/lib/sessionManager/stores/localStorage.ts
+++ b/lib/sessionManager/stores/localStorage.ts
@@ -24,9 +24,9 @@ export class LocalStorage<V extends string = StorageKeys>
    * @returns {void}
    */
   async destroySession(): Promise<void> {
-    this.internalItems.forEach((key) => {
-      this.removeSessionItem(key);
-    });
+    await Promise.all(
+      Array.from(this.internalItems).map((key) => this.removeSessionItem(key)),
+    );
 
     this.notifyListeners();
   }

--- a/lib/sessionManager/stores/localStorage.ts
+++ b/lib/sessionManager/stores/localStorage.ts
@@ -28,7 +28,7 @@ export class LocalStorage<V extends string = StorageKeys>
       this.removeSessionItem(key);
     });
 
-    await this.notifyListeners();
+    this.notifyListeners();
   }
 
   /**
@@ -61,7 +61,7 @@ export class LocalStorage<V extends string = StorageKeys>
       itemValue as string,
     );
 
-    await this.notifyListeners();
+    this.notifyListeners();
   }
 
   /**
@@ -109,6 +109,6 @@ export class LocalStorage<V extends string = StorageKeys>
     }
     this.internalItems.delete(itemKey);
 
-    await this.notifyListeners();
+    this.notifyListeners();
   }
 }

--- a/lib/sessionManager/stores/localStorage.ts
+++ b/lib/sessionManager/stores/localStorage.ts
@@ -27,6 +27,8 @@ export class LocalStorage<V extends string = StorageKeys>
     this.internalItems.forEach((key) => {
       this.removeSessionItem(key);
     });
+
+    await this.notifyListeners();
   }
 
   /**
@@ -58,6 +60,8 @@ export class LocalStorage<V extends string = StorageKeys>
       `${storageSettings.keyPrefix}${itemKey}0`,
       itemValue as string,
     );
+
+    await this.notifyListeners();
   }
 
   /**
@@ -104,5 +108,7 @@ export class LocalStorage<V extends string = StorageKeys>
       index++;
     }
     this.internalItems.delete(itemKey);
+
+    await this.notifyListeners();
   }
 }

--- a/lib/sessionManager/stores/memory.test.ts
+++ b/lib/sessionManager/stores/memory.test.ts
@@ -138,3 +138,294 @@ describe("MemoryStorage keys: storageKeys", () => {
     expect(await sessionManager.getSessionItem(ExtraKeys.testKey)).toBeNull();
   });
 });
+
+describe("MemoryStorage subscription/listening mechanism", () => {
+  let sessionManager: MemoryStorage;
+
+  beforeEach(() => {
+    sessionManager = new MemoryStorage();
+  });
+
+  it("should call listener when item is set", async () => {
+    let listenerCalled = false;
+    const listener = () => {
+      listenerCalled = true;
+    };
+
+    sessionManager.subscribe(listener);
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "testValue");
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    expect(listenerCalled).toBe(true);
+  });
+
+  it("should call listener when item is removed", async () => {
+    let listenerCalled = false;
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "testValue");
+
+    const listener = () => {
+      listenerCalled = true;
+    };
+
+    sessionManager.subscribe(listener);
+    await sessionManager.removeSessionItem(StorageKeys.accessToken);
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    expect(listenerCalled).toBe(true);
+  });
+
+  it("should call listener when session is destroyed", async () => {
+    let listenerCalled = false;
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "testValue");
+
+    const listener = () => {
+      listenerCalled = true;
+    };
+
+    sessionManager.subscribe(listener);
+    await sessionManager.destroySession();
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    expect(listenerCalled).toBe(true);
+  });
+
+  it("should support multiple listeners", async () => {
+    let listener1Called = false;
+    let listener2Called = false;
+    let listener3Called = false;
+
+    const listener1 = () => {
+      listener1Called = true;
+    };
+    const listener2 = () => {
+      listener2Called = true;
+    };
+    const listener3 = () => {
+      listener3Called = true;
+    };
+
+    sessionManager.subscribe(listener1);
+    sessionManager.subscribe(listener2);
+    sessionManager.subscribe(listener3);
+
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "testValue");
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    expect(listener1Called).toBe(true);
+    expect(listener2Called).toBe(true);
+    expect(listener3Called).toBe(true);
+  });
+
+  it("should support asynchronous listeners", async () => {
+    let asyncListenerCalled = false;
+    let asyncListenerValue = "";
+
+    const asyncListener = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      asyncListenerCalled = true;
+      asyncListenerValue = (await sessionManager.getSessionItem(
+        StorageKeys.accessToken,
+      )) as string;
+    };
+
+    sessionManager.subscribe(asyncListener);
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "asyncTest");
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    // Wait a bit more for async listener to complete
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(asyncListenerCalled).toBe(true);
+    expect(asyncListenerValue).toBe("asyncTest");
+  });
+
+  it("should support mix of synchronous and asynchronous listeners", async () => {
+    let syncCalled = false;
+    let asyncCalled = false;
+
+    const syncListener = () => {
+      syncCalled = true;
+    };
+
+    const asyncListener = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      asyncCalled = true;
+    };
+
+    sessionManager.subscribe(syncListener);
+    sessionManager.subscribe(asyncListener);
+
+    await sessionManager.setSessionItem(StorageKeys.idToken, "mixedTest");
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    expect(syncCalled).toBe(true);
+
+    // Wait for async listener
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(asyncCalled).toBe(true);
+  });
+
+  it("should unsubscribe listener when unsubscribe function is called", async () => {
+    let listenerCalled = false;
+
+    const listener = () => {
+      listenerCalled = true;
+    };
+
+    const unsubscribe = sessionManager.subscribe(listener);
+
+    // First change should trigger listener
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "test1");
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+    expect(listenerCalled).toBe(true);
+
+    // Reset and unsubscribe
+    listenerCalled = false;
+    unsubscribe();
+
+    // Second change should not trigger listener
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "test2");
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+    expect(listenerCalled).toBe(false);
+  });
+
+  it("should batch multiple synchronous calls into single notification", async () => {
+    let callCount = 0;
+
+    const listener = () => {
+      callCount++;
+    };
+
+    sessionManager.subscribe(listener);
+
+    // Perform multiple operations synchronously
+    const promise1 = sessionManager.setSessionItem(
+      StorageKeys.accessToken,
+      "value1",
+    );
+    const promise2 = sessionManager.setSessionItem(
+      StorageKeys.idToken,
+      "value2",
+    );
+    const promise3 = sessionManager.setSessionItem(
+      StorageKeys.refreshToken,
+      "value3",
+    );
+
+    await Promise.all([promise1, promise2, promise3]);
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    // Even though we made 3 changes, listener should be called more than once
+    // but less than 3 times due to batching
+    expect(callCount).toBeGreaterThan(0);
+    expect(callCount).toBeLessThanOrEqual(3);
+  });
+
+  it("should allow same listener to be subscribed multiple times", async () => {
+    let callCount = 0;
+
+    const listener = () => {
+      callCount++;
+    };
+
+    // Subscribe same listener twice
+    sessionManager.subscribe(listener);
+    sessionManager.subscribe(listener);
+
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "testValue");
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    // Since Set is used, listener should only be called once
+    expect(callCount).toBe(1);
+  });
+
+  it("should support unsubscribing one instance while keeping others", async () => {
+    let listener1Called = false;
+    let listener2Called = false;
+
+    const listener1 = () => {
+      listener1Called = true;
+    };
+
+    const listener2 = () => {
+      listener2Called = true;
+    };
+
+    const unsubscribe1 = sessionManager.subscribe(listener1);
+    sessionManager.subscribe(listener2);
+
+    // Unsubscribe first listener
+    unsubscribe1();
+
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "testValue");
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    expect(listener1Called).toBe(false);
+    expect(listener2Called).toBe(true);
+  });
+
+  it("should notify listeners on setItems batch operation", async () => {
+    let listenerCallCount = 0;
+
+    const listener = () => {
+      listenerCallCount++;
+    };
+
+    sessionManager.subscribe(listener);
+
+    await sessionManager.setItems({
+      [StorageKeys.accessToken]: "token1",
+      [StorageKeys.idToken]: "token2",
+      [StorageKeys.refreshToken]: "token3",
+    });
+
+    // Wait for microtask queue to flush
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    // Should be called at least once (batching may reduce call count)
+    expect(listenerCallCount).toBeGreaterThan(0);
+  });
+
+  it("should not batch multiple calls when operations are separated by microtask boundaries", async () => {
+    const callLog: string[] = [];
+
+    const listener = () => {
+      callLog.push("listener called");
+    };
+
+    sessionManager.subscribe(listener);
+
+    // Set item
+    await sessionManager.setSessionItem(StorageKeys.accessToken, "test1");
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    // Remove item
+    await sessionManager.removeSessionItem(StorageKeys.accessToken);
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    // Set another item
+    await sessionManager.setSessionItem(StorageKeys.idToken, "test2");
+    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+    // Each operation should trigger the listener when awaited between operations
+    expect(callLog.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/lib/sessionManager/stores/memory.ts
+++ b/lib/sessionManager/stores/memory.ts
@@ -18,7 +18,7 @@ export class MemoryStorage<V extends string = StorageKeys>
    */
   async destroySession(): Promise<void> {
     this.memCache = {};
-    await this.notifyListeners();
+    this.notifyListeners();
   }
 
   /**
@@ -46,7 +46,7 @@ export class MemoryStorage<V extends string = StorageKeys>
     this.memCache[`${storageSettings.keyPrefix}${String(itemKey)}0`] =
       itemValue;
 
-    await this.notifyListeners();
+    this.notifyListeners();
   }
 
   /**
@@ -87,6 +87,6 @@ export class MemoryStorage<V extends string = StorageKeys>
       }
     }
 
-    await this.notifyListeners();
+    this.notifyListeners();
   }
 }

--- a/lib/sessionManager/stores/memory.ts
+++ b/lib/sessionManager/stores/memory.ts
@@ -18,6 +18,7 @@ export class MemoryStorage<V extends string = StorageKeys>
    */
   async destroySession(): Promise<void> {
     this.memCache = {};
+    await this.notifyListeners();
   }
 
   /**
@@ -44,6 +45,8 @@ export class MemoryStorage<V extends string = StorageKeys>
     }
     this.memCache[`${storageSettings.keyPrefix}${String(itemKey)}0`] =
       itemValue;
+
+    await this.notifyListeners();
   }
 
   /**
@@ -83,5 +86,7 @@ export class MemoryStorage<V extends string = StorageKeys>
         delete this.memCache[key];
       }
     }
+
+    await this.notifyListeners();
   }
 }

--- a/lib/sessionManager/stores/memory.ts
+++ b/lib/sessionManager/stores/memory.ts
@@ -41,6 +41,7 @@ export class MemoryStorage<V extends string = StorageKeys>
             splitValue;
         },
       );
+      this.notifyListeners();
       return;
     }
     this.memCache[`${storageSettings.keyPrefix}${String(itemKey)}0`] =


### PR DESCRIPTION
Added a subscription pattern to `SessionBase` so you can listen for changes. You can now subscribe to storage updates and do something when things change. Also added some smart batching using microtasks so we don't spam listeners when multiple operations happen at once.

Tests have been updated to comprehensively test:
- Listeners trigger on set/remove/destroy
- Multiple listeners work fine
- Async listeners are supported
- Mix of sync and async listeners
- Unsubscribe works as expected
- Batching multiple sync operations
- Can't accidentally subscribe twice (using Set)
- Can unsubscribe specific listeners
- Batch operations like setItems work
- Microtask boundary behavior

Chrome Storage and Expo Secure Store tests have been omitted for the time being as they're skipped entirely.

## How to Use It

### Node/TS
```typescript
const store = new LocalStorage();

const unsubscribe = store.subscribe(async () => {
  console.log('Store updated');
  // do whatever you need when the store changes
});

await store.setSessionItem(StorageKeys.accessToken, 'new-token');
// listener gets called here

unsubscribe(); // clean up when you're done
```

### React
```tsx
useEffect(() => {
  const unsubscribe = store.subscribe(async () => {
    // do things
  });
  // unsubscribe on unmount
  return unsubscribe;
}, [store]);
```