### PR TITLE
feat: tightened the RefreshToken response type

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -244,13 +244,25 @@ export type PKCEChallengeState = PKCEChallenge & {
   state: string;
 };
 
-export interface RefreshTokenResult {
-  success: boolean;
+export interface RefreshTokenResultError {
+  success: false;
   error?: string;
+  [StorageKeys.accessToken]?: never;
+  [StorageKeys.idToken]?: never;
+  [StorageKeys.refreshToken]?: never;
+}
+
+export interface RefreshTokenResultSuccess {
+  success: true;
+  error?: never;
   [StorageKeys.accessToken]?: string;
   [StorageKeys.idToken]?: string;
   [StorageKeys.refreshToken]?: string;
 }
+
+export type RefreshTokenResult =
+  | RefreshTokenResultError
+  | RefreshTokenResultSuccess;
 
 export enum RefreshType {
   refreshToken,


### PR DESCRIPTION
# Explain your changes

Update the RefreshTokenResult to be more explict on the data to be reponded with on success or failure

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
