### PR TITLE
chore(deps): upgrade expo-secure-store to 14.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/chrome": "^0.1.0",
     "@types/node": "^24.0.0",
     "@vitejs/plugin-react": "^5.0.0",
+    "expo-secure-store": "14.2.4",
     "@vitest/coverage-v8": "^4.0.3",
     "eslint": "^9.9.1",
     "globals": "^17.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@kinde/jwt-decoder':
         specifier: ^0.2.0
         version: 0.2.0
-      expo-secure-store:
-        specifier: '>=11.0.0'
-        version: 14.0.1(expo@52.0.46(@babel/core@7.28.4)(@babel/preset-env@7.26.9(@babel/core@7.28.4))(react-native@0.79.1(@babel/core@7.28.4)(react@19.1.0))(react@19.1.0))
     devDependencies:
       '@eslint/js':
         specifier: ^9.9.1
@@ -33,6 +30,9 @@ importers:
       eslint:
         specifier: ^9.9.1
         version: 9.37.0
+      expo-secure-store:
+        specifier: 14.2.4
+        version: 14.2.4(expo@52.0.46(@babel/core@7.28.4)(@babel/preset-env@7.26.9(@babel/core@7.28.4))(react-native@0.79.1(@babel/core@7.28.4)(react@19.1.0))(react@19.1.0))
       globals:
         specifier: ^17.0.0
         version: 17.0.0
@@ -1682,11 +1682,12 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -2437,8 +2438,8 @@ packages:
   expo-modules-core@2.2.3:
     resolution: {integrity: sha512-01QqZzpP/wWlxnNly4G06MsOBUTbMDj02DQigZoXfDh80vd/rk3/uVXqnZgOdLSggTs6DnvOgAUy0H2q30XdUg==}
 
-  expo-secure-store@14.0.1:
-    resolution: {integrity: sha512-QUS+j4+UG4jRQalgnpmTvvrFnMVLqPiUZRzYPnG3+JrZ5kwVW2w6YS3WWerPoR7C6g3y/a2htRxRSylsDs+TaQ==}
+  expo-secure-store@14.2.4:
+    resolution: {integrity: sha512-ePaz4fnTitJJZjAiybaVYGfLWWyaEtepZC+vs9ZBMhQMfG5HUotIcVsDaSo3FnwpHmgwsLVPY2qFeryI6AtULw==}
     peerDependencies:
       expo: '*'
 
@@ -7395,7 +7396,7 @@ snapshots:
     dependencies:
       invariant: 2.2.4
 
-  expo-secure-store@14.0.1(expo@52.0.46(@babel/core@7.28.4)(@babel/preset-env@7.26.9(@babel/core@7.28.4))(react-native@0.79.1(@babel/core@7.28.4)(react@19.1.0))(react@19.1.0)):
+  expo-secure-store@14.2.4(expo@52.0.46(@babel/core@7.28.4)(@babel/preset-env@7.26.9(@babel/core@7.28.4))(react-native@0.79.1(@babel/core@7.28.4)(react@19.1.0))(react@19.1.0)):
     dependencies:
       expo: 52.0.46(@babel/core@7.28.4)(@babel/preset-env@7.26.9(@babel/core@7.28.4))(react-native@0.79.1(@babel/core@7.28.4)(react@19.1.0))(react@19.1.0)
 


### PR DESCRIPTION
## Summary

Supersedes and closes #199 - the Snyk PR that had **zero file changes** (empty diff, could not be merged).

## Why #199 could not be merged

PR #199 was created by Snyk to upgrade `expo-secure-store` from `14.0.1` to `14.2.4`, but its branch contained **no actual file changes**. The PR was stale and could never be merged.

The root cause: `expo-secure-store` was only declared in `peerDependencies` (`>=11.0.0`) and was auto-installed by pnpm's `autoInstallPeers: true` at `14.0.1`. Updating an auto-installed peer dep requires explicitly pinning it in `devDependencies` - otherwise `pnpm update` has no effect on it.

## Changes in this PR

| File | Change |
|---|---|
| `package.json` | Added `"expo-secure-store": "14.2.4"` to `devDependencies` |
| `pnpm-lock.yaml` | Resolved from `14.0.1` → `14.2.4` |

The `peerDependencies` range (`>=11.0.0`) is **unchanged** - consumers can still bring any compatible version.

Adding an optional peer dependency to `devDependencies` at the version used for testing is standard practice for npm libraries.

## Changelog (14.0.1 → 14.2.4)

| Version | Changes |
|---|---|
| `14.1.0` | [Android] Expo modules gradle plugin; [iOS] Swift 6 fixes |
| `14.2.0` | [iOS] Added access group support (new additive optional feature) |
| `14.2.1` – `14.2.4` | No user-facing changes |

**No breaking changes. No migration required.** Snyk confirmed `isBreakingChange: false`.

## Test results

All **616 tests pass**, 2 skipped (same as before).

---

Linked PR: #199