### PR TITLE
chore(ci): upgrade pnpm/action-setup from v4 to v6

### DIFF
--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -14,7 +14,7 @@ jobs:
         node-version: [20.x]
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - name: Setting up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary

Upgrades `pnpm/action-setup` from `v4` to `v6` in the CI workflow.

**Replaces: #211** (Renovate PR - CI was broken on the Renovate branch and it is protected, so we cannot push a fix there.)

---

## Change

Single-line change in `.github/workflows/build-test-ci.yml`:

```diff
- uses: pnpm/action-setup@v4
+ uses: pnpm/action-setup@v6
```

---

## Compatibility

`pnpm/action-setup@v6` reads the `packageManager` field from `package.json` to determine which pnpm version to install. This project has `"packageManager": "pnpm@10.18.1+sha512..."`, so the action will continue installing pnpm 10.18.1 - no lockfile format changes or other side-effects expected.