### PR TITLE
fix(deps): bump lodash to 4.17.23 (security patch - prototype pollution)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1706,6 +1706,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
@@ -3106,8 +3111,8 @@ packages:
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   log-symbols@2.2.0:
     resolution: {integrity: sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==}
@@ -5966,7 +5971,7 @@ snapshots:
       '@rushstack/rig-package': 0.5.3
       '@rushstack/terminal': 0.15.3(@types/node@24.9.1)
       '@rushstack/ts-command-line': 5.0.1(@types/node@24.9.1)
-      lodash: 4.17.21
+      lodash: 4.17.23
       minimatch: 3.0.8
       resolve: 1.22.10
       semver: 7.5.4
@@ -6596,6 +6601,8 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  acorn@8.16.0: {}
 
   aggregate-error@3.1.0:
     dependencies:
@@ -8114,7 +8121,7 @@ snapshots:
 
   lodash.throttle@4.1.1: {}
 
-  lodash@4.17.21: {}
+  lodash@4.17.23: {}
 
   log-symbols@2.2.0:
     dependencies:
@@ -9137,7 +9144,7 @@ snapshots:
   terser@5.39.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.15.0
+      acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
 


### PR DESCRIPTION
## Summary

Security patch bump for `lodash` (transitive dependency), replacing the stale Dependabot PR #196 which could not be updated due to branch protection.

**Replaces: #196**

---

## Changes (lockfile-only)

| Package | Before | After | Type |
|---|---|---|---|
| `lodash` | `4.17.21` | `4.17.23` | Patch - security fix |
| `acorn` | `8.15.0` | `8.16.0` | Minor - picked up in same resolution pass |

Both are **transitive dependencies** via `@rushstack` packages (used by `vite-plugin-dts`). No changes to `package.json`.

---

## Why not merge #196 directly?

PR #196 is based on `main` from January 2026 - the Dependabot branch is protected and cannot be updated. Rather than risking a merge of a 3-month-old branch, this PR applies the same fix cleanly on top of current `main`.

---

## Migration required?

**No.** This is a patch-level security fix within lodash 4.x. The changelog commits are:

- `edadd45` - Prevent prototype pollution on `baseUnset` function (**security fix**)
- `19c9251` - Fix `setCacheHas` JSDoc return type (docs only)
- `b5e6729` - Add `-0` and `BigInt` zeros to `_.compact` docs (docs only)

No API changes, no breaking changes. Zero migration work needed.

---

## Test results

- ✅ `pnpm test --run` - 616 tests pass, 20 skipped