### PR TITLE
chore(ci): upgrade actions/cache from v4 to v5 [REDUNDANT - close this]

### DIFF
--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - run: pnpm install
       - run: pnpm lint
       - name: Cache pnpm modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}


### PR DESCRIPTION
~~Replaces: #194~~

This PR is redundant — created based on a mistaken belief that #194's CI was failing. #194's CI is fully green; it just needs a code owner review. Please merge #194 directly and close this PR.