### PR TITLE
chore(deps): upgrade expo-secure-store to v55.0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/chrome": "^0.1.0",
     "@types/node": "^24.0.0",
     "@vitejs/plugin-react": "^6.0.0",
-    "expo-secure-store": "14.2.4",
+    "expo-secure-store": "55.0.13",
     "@vitest/coverage-v8": "^4.0.3",
     "eslint": "^9.9.1",
     "globals": "^17.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^9.9.1
         version: 9.37.0
       expo-secure-store:
-        specifier: 14.2.4
-        version: 14.2.4(expo@52.0.46(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(react-native@0.79.1(@babel/core@7.29.0)(react@19.1.0))(react@19.1.0))
+        specifier: 55.0.13
+        version: 55.0.13(expo@52.0.46(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(react-native@0.79.1(@babel/core@7.29.0)(react@19.1.0))(react@19.1.0))
       globals:
         specifier: ^17.0.0
         version: 17.0.0
@@ -2616,8 +2616,8 @@ packages:
   expo-modules-core@2.2.3:
     resolution: {integrity: sha512-01QqZzpP/wWlxnNly4G06MsOBUTbMDj02DQigZoXfDh80vd/rk3/uVXqnZgOdLSggTs6DnvOgAUy0H2q30XdUg==}
 
-  expo-secure-store@14.2.4:
-    resolution: {integrity: sha512-ePaz4fnTitJJZjAiybaVYGfLWWyaEtepZC+vs9ZBMhQMfG5HUotIcVsDaSo3FnwpHmgwsLVPY2qFeryI6AtULw==}
+  expo-secure-store@55.0.13:
+    resolution: {integrity: sha512-I6r0JNO1Fd4o0Gu7Ixiic7s89lqgdUHq17uBH9y1f/AntoyKn71TdtYJH82RgfsBbu5qNVzrwImmvlANyOlITQ==}
     peerDependencies:
       expo: '*'
 
@@ -7830,7 +7830,7 @@ snapshots:
     dependencies:
       invariant: 2.2.4
 
-  expo-secure-store@14.2.4(expo@52.0.46(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(react-native@0.79.1(@babel/core@7.29.0)(react@19.1.0))(react@19.1.0)):
+  expo-secure-store@55.0.13(expo@52.0.46(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(react-native@0.79.1(@babel/core@7.29.0)(react@19.1.0))(react@19.1.0)):
     dependencies:
       expo: 52.0.46(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(react-native@0.79.1(@babel/core@7.29.0)(react@19.1.0))(react@19.1.0)
 


### PR DESCRIPTION
## Summary

Upgrades `expo-secure-store` from `14.2.4` → `55.0.13` (conflict-free replacement for #219).

PR #219 was generated by Renovate but had conflicts in `package.json` and `pnpm-lock.yaml` due to concurrent merges on `main`. This PR applies the same change cleanly on top of the latest `main`.

## Migration analysis

`expo-secure-store` switched to Expo SDK-aligned versioning (v14 → Expo SDK 52, v55 → Expo SDK 55). The large version jump is a versioning scheme change, not 40 breaking iterations.

**All breaking changes between v14.2.4 and v55.0.13 are platform minimum version bumps only (iOS deployment target, Android SDK target). There are zero JavaScript API changes.**

The three methods this codebase uses are unchanged in v55:
- `setItemAsync(key, value)` ✅
- `getItemAsync(key)` ✅  
- `deleteItemAsync(key)` ✅

The existing `peerDependencies` range `"expo-secure-store": ">=11.0.0"` already covers v55 — no additional changes needed.

## Changes

- `package.json`: bump dev dependency pin `14.2.4` → `55.0.13`
- `pnpm-lock.yaml`: regenerated lock file

Closes #219