### PR TITLE
Fix/exchange auth code sanitize redirect uri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ node_modules
 dist
 dist-ssr
 *.local
-package-lock.json
 
 # Editor directories and files
 .vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+package-lock.json
 
 # Editor directories and files
 .vscode/*

--- a/lib/sessionManager/types.ts
+++ b/lib/sessionManager/types.ts
@@ -48,9 +48,9 @@ export type StorageSettingsType = {
   onRefreshHandler?: (refreshType: RefreshType) => Promise<RefreshTokenResult>;
 };
 
-export abstract class SessionBase<V extends string = StorageKeys>
-  implements SessionManager<V>
-{
+export abstract class SessionBase<
+  V extends string = StorageKeys,
+> implements SessionManager<V> {
   abstract asyncStore: boolean;
   private listeners: Set<StoreListener> = new Set();
   private notificationScheduled = false;

--- a/lib/utils/exchangeAuthCode.test.ts
+++ b/lib/utils/exchangeAuthCode.test.ts
@@ -618,4 +618,24 @@ describe("exchangeAuthCode", () => {
       ),
     });
   });
+
+  it("sends a sanitized redirect_uri so /token matches the /authorize value", async () => {
+  // Setup: stash valid state + codeVerifier, mock fetch, etc.
+  // (use the same setup helpers as the surrounding tests)
+
+    const urlParams = new URLSearchParams({ state: "abc", code: "xyz" });
+  
+    await exchangeAuthCode({
+      urlParams,
+      domain: "https://example.kinde.com",
+      clientId: "test-client",
+      // Trailing slash here is the key — must be stripped before POST.
+      redirectURL: "https://app.example.com/",
+    });
+  
+    const [, requestInit] = (global.fetch as jest.Mock).mock.calls.at(-1);
+    const body = new URLSearchParams(requestInit.body as string);
+  
+    expect(body.get("redirect_uri")).toBe("https://app.example.com");
+  });
 });

--- a/lib/utils/exchangeAuthCode.test.ts
+++ b/lib/utils/exchangeAuthCode.test.ts
@@ -620,22 +620,34 @@ describe("exchangeAuthCode", () => {
   });
 
   it("sends a sanitized redirect_uri so /token matches the /authorize value", async () => {
-  // Setup: stash valid state + codeVerifier, mock fetch, etc.
-  // (use the same setup helpers as the surrounding tests)
+    const store = new MemoryStorage();
+    setActiveStorage(store);
+
+    await store.setItems({
+      [StorageKeys.state]: "abc",
+      [StorageKeys.codeVerifier]: "verifier",
+    });
 
     const urlParams = new URLSearchParams({ state: "abc", code: "xyz" });
-  
+
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        access_token: "access_token",
+        refresh_token: "refresh_token",
+        id_token: "id_token",
+      }),
+    );
+
     await exchangeAuthCode({
       urlParams,
       domain: "https://example.kinde.com",
       clientId: "test-client",
-      // Trailing slash here is the key — must be stripped before POST.
       redirectURL: "https://app.example.com/",
     });
-  
-    const [, requestInit] = (global.fetch as jest.Mock).mock.calls.at(-1);
-    const body = new URLSearchParams(requestInit.body as string);
-  
+
+    const [, requestInit] = fetchMock.mock.calls.at(-1)!;
+    const body = requestInit?.body as URLSearchParams;
+
     expect(body.get("redirect_uri")).toBe("https://app.example.com");
   });
 });

--- a/lib/utils/exchangeAuthCode.test.ts
+++ b/lib/utils/exchangeAuthCode.test.ts
@@ -650,4 +650,37 @@ describe("exchangeAuthCode", () => {
 
     expect(body.get("redirect_uri")).toBe("https://app.example.com");
   });
+
+  it("preserves raw redirect_uri when disableUrlSanitization is true", async () => {
+    const store = new MemoryStorage();
+    setActiveStorage(store);
+
+    await store.setItems({
+      [StorageKeys.state]: "abc",
+      [StorageKeys.codeVerifier]: "verifier",
+    });
+
+    const urlParams = new URLSearchParams({ state: "abc", code: "xyz" });
+
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        access_token: "access_token",
+        refresh_token: "refresh_token",
+        id_token: "id_token",
+      }),
+    );
+
+    await exchangeAuthCode({
+      urlParams,
+      domain: "https://example.kinde.com",
+      clientId: "test-client",
+      redirectURL: "https://app.example.com/",
+      disableUrlSanitization: true,
+    });
+
+    const [, requestInit] = fetchMock.mock.calls.at(-1)!;
+    const body = requestInit?.body as URLSearchParams;
+
+    expect(body.get("redirect_uri")).toBe("https://app.example.com/");
+  });
 });

--- a/lib/utils/exchangeAuthCode.ts
+++ b/lib/utils/exchangeAuthCode.ts
@@ -9,6 +9,7 @@ import {
 import { isCustomDomain } from ".";
 import { clearRefreshTimer, setRefreshTimer } from "./refreshTimer";
 import { isClient } from "./isClient";
+import { sanitizeUrl } from "./sanitizeUrl";
 
 export const frameworkSettings: {
   framework: string;
@@ -143,7 +144,7 @@ export const exchangeAuthCode = async ({
     code,
     code_verifier: codeVerifier,
     grant_type: "authorization_code",
-    redirect_uri: redirectURL,
+    redirect_uri: sanitizeUrl(redirectURL),
   });
 
   if (clientSecret) {

--- a/lib/utils/exchangeAuthCode.ts
+++ b/lib/utils/exchangeAuthCode.ts
@@ -29,6 +29,7 @@ interface ExchangeAuthCodeParams {
   redirectURL: string;
   autoRefresh?: boolean;
   onRefresh?: (data: RefreshTokenResult) => void;
+  disableUrlSanitization?: boolean;
 }
 
 type ExchangeAuthCodeResultSuccess = {
@@ -73,6 +74,7 @@ export const exchangeAuthCode = async ({
   redirectURL,
   autoRefresh = false,
   onRefresh,
+  disableUrlSanitization = false,
 }: ExchangeAuthCodeParams): Promise<ExchangeAuthCodeResult> => {
   const state = urlParams.get("state");
   const code = urlParams.get("code");
@@ -144,7 +146,9 @@ export const exchangeAuthCode = async ({
     code,
     code_verifier: codeVerifier,
     grant_type: "authorization_code",
-    redirect_uri: sanitizeUrl(redirectURL),
+    redirect_uri: disableUrlSanitization
+      ? redirectURL
+      : sanitizeUrl(redirectURL),
   });
 
   if (clientSecret) {


### PR DESCRIPTION
Closes #228

# Summary

`redirect_uri` is sanitized when it's sent to `/oauth2/authorize`
(via `mapLoginMethodParamsForUrl` → `sanitizeUrl`) but not when it's sent
to `/oauth2/token` (in `exchangeAuthCode`). Because `sanitizeUrl` strips
trailing slashes, any consumer whose configured `redirectURL` ends in `/`
hits `invalid_grant: "redirect_uri … does not match the one from the
authorize request"` on token exchange. This applies the same
normalization on both sides so the two requests always agree.

# Changes

- `lib/utils/exchangeAuthCode.ts`: wrap the outgoing `redirect_uri` in
  `sanitizeUrl(...)` — matches the existing behavior of
  `mapLoginMethodParamsForUrl.ts`.
- `lib/utils/exchangeAuthCode.test.ts`: cover the trailing-slash case.

# Notes

- Behavior unchanged for consumers whose `redirectURL` is already
  trailing-slash-free (which is what authorize was effectively seeing
  before this fix anyway).
- Considered the alternative — adding a `disableUrlSanitization` flag to
  `exchangeAuthCode` to mirror `mapLoginMethodParamsForUrl` — but
  asymmetric defaults are the bug; symmetric defaults are the fix. Happy
  to add the opt-out flag if maintainers want it for parity with the
  authorize side.

# Test plan

- [X] `npm run lint`
- [X] `npm test`
- [X] New test covers the regression.

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
