### PR TITLE
fix: set entryRoot and rootDir to lib for d.ts emit

### DIFF
--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -32,6 +32,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-
       - run: pnpm build
+      - name: Verify published types entry
+        run: |
+          test -f dist/main.d.ts
+          test "$(wc -c < dist/main.d.ts)" -gt 50
+          ! grep -q '^export {}$' dist/main.d.ts
       - run: pnpm test:coverage
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v6.0.2

--- a/lib/dist-types.test.ts
+++ b/lib/dist-types.test.ts
@@ -9,29 +9,46 @@ const distDir = resolve(rootDir, "../dist");
 const mainDts = resolve(distDir, "main.d.ts");
 const libMainDts = resolve(distDir, "lib/main.d.ts");
 
+const getExportNames = (entryPath: string): string[] => {
+  const program = ts.createProgram([entryPath], {
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ES2022,
+    skipLibCheck: true,
+  });
+  const checker = program.getTypeChecker();
+  const sourceFile = program.getSourceFile(entryPath);
+  expect(sourceFile).toBeDefined();
+
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile!);
+  expect(moduleSymbol).toBeDefined();
+
+  return checker.getExportsOfModule(moduleSymbol!).map((symbol) => symbol.name);
+};
+
 describe("dist type declarations", () => {
-  it("should expose PortalPage via the package types entry", () => {
+  it("should emit a flat dist layout with real declarations at dist/main.d.ts", () => {
     expect(existsSync(mainDts)).toBe(true);
-    expect(existsSync(libMainDts)).toBe(true);
+    expect(existsSync(libMainDts)).toBe(false);
 
     const entryContent = readFileSync(mainDts, "utf-8");
-    expect(entryContent).toContain("./lib/main");
+    expect(entryContent.trim()).not.toBe("export {}");
+    expect(entryContent.length).toBeGreaterThan(50);
+    expect(entryContent).not.toContain("./lib/main");
+  });
 
-    const program = ts.createProgram([mainDts], {
-      moduleResolution: ts.ModuleResolutionKind.Bundler,
-      module: ts.ModuleKind.ESNext,
-      target: ts.ScriptTarget.ES2022,
-      skipLibCheck: true,
-    });
-    const checker = program.getTypeChecker();
-    const sourceFile = program.getSourceFile(mainDts);
-    expect(sourceFile).toBeDefined();
+  it("should expose public API symbols via the package types entry", () => {
+    const exportNames = getExportNames(mainDts);
 
-    const moduleSymbol = checker.getSymbolAtLocation(sourceFile!);
-    expect(moduleSymbol).toBeDefined();
-
-    const exports = checker.getExportsOfModule(moduleSymbol!);
-    const portalPage = exports.find((symbol) => symbol.name === "PortalPage");
-    expect(portalPage).toBeDefined();
+    for (const symbolName of [
+      "PortalPage",
+      "setRefreshTimer",
+      "generateAuthUrl",
+      "MemoryStorage",
+      "setActiveStorage",
+      "switchOrg",
+    ]) {
+      expect(exportNames).toContain(symbolName);
+    }
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["node", "chrome"],
     "skipLibCheck": true,
-
+    "rootDir": "./lib",
     /* Bundler mode */
     "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,17 +29,9 @@ export default defineConfig({
   resolve: { alias: { src: resolve(rootDir, "./lib") } },
   plugins: [
     dts({
+      insertTypesEntry: true,
       outDir: "dist",
-      // insertTypesEntry writes an empty dist/main.d.ts when declarations are
-      // emitted under dist/lib/ (vite 8 + vite-plugin-dts). Write the shim in
-      // afterBuild instead.
-      afterBuild: async () => {
-        const { writeFile } = await import("node:fs/promises");
-        await writeFile(
-          resolve(rootDir, "dist/main.d.ts"),
-          "export * from './lib/main'\n",
-        );
-      },
+      entryRoot: "lib",
     }),
     react(),
   ],


### PR DESCRIPTION
## Explain your changes

After **v0.30.2**, downstream SDKs started failing with errors like:

```text
Module '"@kinde/js-utils"' has no exported member 'setRefreshTimer'
Module '"@kinde/js-utils"' has no exported member 'generateAuthUrl'
...
```

### Investigation

We compared the published npm packages:

| Version | `dist/main.d.ts` | Declaration layout |
|---------|------------------|--------------------|
| **0.30.1** | ~1.7 kB, full exports | `dist/main.d.ts`, `dist/utils/`, `dist/sessionManager/` |
| **0.30.2** | 10 B stub (`export {}`) | Real types under `dist/lib/` |

The runtime JS bundles were fine; only the **TypeScript declaration entry** was wrong. `package.json` still pointed consumers at `dist/main.d.ts`, which in 0.30.2 was an empty stub from `vite-plugin-dts` `insertTypesEntry: true`, while the real declarations had moved to `dist/lib/main.d.ts`.

Between **0.30.1** (`4feba30`) and **0.30.2** (`1cadd02`):

- No changes to `lib/main.ts`, `package.json` `types`/`exports`, or the build script
- **`vite.config.ts` and `tsconfig.json` were unchanged** on those tags
- Changes were mainly **`pnpm-lock.yaml` refreshes** (Renovate), including:
  - `vite` 8.0.10 → 8.0.14
  - `rolldown` 1.0.0-rc.17 → 1.0.2
  - `typescript` 6.0.2 → 6.0.3
  - `expo-secure-store` 55 → 56

`vite-plugin-dts` stayed at **4.5.4** in both releases. The regression appears to come from **declaration output path resolution** changing after the lockfile/toolchain update, not from removing exports from source.

### Fix

Pin declaration emit back to the pre-0.30.2 layout:

1. **`vite.config.ts`** — set `entryRoot: "lib"` on `vite-plugin-dts` so `lib/` is stripped from output paths and the public entry stays at `dist/main.d.ts`
2. **`tsconfig.json`** — set `"rootDir": "./lib"` so TypeScript 6’s default `rootDir` (project root) does not preserve `lib/` in emitted declaration paths

### Verification

After applying the fix:

```bash
pnpm install
pnpm build
wc -c dist/main.d.ts
head dist/main.d.ts
```

Expected:

- `dist/main.d.ts` contains full exports (`setRefreshTimer`, `generateAuthUrl`, `MemoryStorage`, etc.)
- `dist/main.d.ts` is **not** `export {}`
- Declaration layout matches **0.30.1** (`dist/main.d.ts` at package root, not only under `dist/lib/`)

---

## Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
